### PR TITLE
Implement notifications for pending/success/error state of zip creation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,6 +15,6 @@
 	<bugs>https://github.com/rullzer/files_zip/issues</bugs>
 	<repository type="git">https://github.com/rullzer/files_zip.git</repository>
 	<dependencies>
-		<nextcloud min-version="22" max-version="22" />
+		<nextcloud min-version="22" max-version="23" />
 	</dependencies>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,6 +28,7 @@ namespace OCA\FilesZip\AppInfo;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\FilesZip\Capabilities;
 use OCA\FilesZip\Listener\LoadAdditionalListener;
+use OCA\FilesZip\Notification\Notifier;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -43,6 +44,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
 		$context->registerCapability(Capabilities::class);
+		$context->registerNotifierService(Notifier::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Exceptions/TargetAlreadyExists.php
+++ b/lib/Exceptions/TargetAlreadyExists.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\FilesZip\Exceptions;
+
+use Exception;
+
+class TargetAlreadyExists extends Exception {
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,117 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\FilesZip\Notification;
+
+use InvalidArgumentException;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+
+class Notifier implements INotifier {
+	public const TYPE_SCHEDULED = 'zip_scheduled';
+	public const TYPE_SUCCESS = 'zip_success';
+	public const TYPE_FAILURE = 'zip_error';
+
+	/** @var IFactory */
+	protected $factory;
+	/** @var IURLGenerator */
+	protected $url;
+
+	public function __construct(IFactory $factory, IURLGenerator $urlGenerator) {
+		$this->factory = $factory;
+		$this->url = $urlGenerator;
+	}
+
+	public function getID(): string {
+		return 'files_zip';
+	}
+
+	public function getName(): string {
+		return $this->factory->get('files_zip')->t('Zipper');
+	}
+
+	public function prepare(INotification $notification, string $languageCode): INotification {
+		if ($notification->getApp() !== 'files_zip') {
+			throw new InvalidArgumentException('Application should be files_zip instead of ' . $notification->getApp());
+		}
+
+		$l = $this->factory->get('files_zip', $languageCode);
+
+		switch ($notification->getSubject()) {
+			case self::TYPE_SCHEDULED:
+				$parameters = $notification->getSubjectParameters();
+				$notification->setRichSubject($l->t('A zip archive {target} will be created.'), [
+					'target' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => $parameters['target-name'],
+					]
+				]);
+				break;
+			case self::TYPE_SUCCESS:
+				$parameters = $notification->getSubjectParameters();
+				$notification->setRichSubject($l->t('Your files have been stored as a zip archive in {path}.'), [
+					'path' => [
+						'type' => 'file',
+						'id' => $parameters['fileid'],
+						'name' => $parameters['name'],
+						'path' => $parameters['path']
+					]
+				]);
+				break;
+			case self::TYPE_FAILURE:
+				$parameters = $notification->getSubjectParameters();
+				$notification->setRichSubject($l->t('Creating the zip file {path} failed.'), [
+					'path' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => basename($parameters['target']),
+					]
+				]);
+				break;
+			default:
+				throw new InvalidArgumentException();
+		}
+		$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('files_zip', 'files_zip-dark.svg')));
+		$this->setParsedSubjectFromRichSubject($notification);
+		return $notification;
+	}
+
+	protected function setParsedSubjectFromRichSubject(INotification $notification): void {
+		$placeholders = $replacements = [];
+		foreach ($notification->getRichSubjectParameters() as $placeholder => $parameter) {
+			$placeholders[] = '{' . $placeholder . '}';
+			if ($parameter['type'] === 'file') {
+				$replacements[] = $parameter['path'];
+			} else {
+				$replacements[] = $parameter['name'];
+			}
+		}
+
+		$notification->setParsedSubject(str_replace($placeholders, $replacements, $notification->getRichSubject()));
+	}
+}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\FilesZip\Service;
+
+use DateTime;
+use OCA\FilesZip\BackgroundJob\ZipJob;
+use OCA\FilesZip\Notification\Notifier;
+use OCP\Files\File;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+
+class NotificationService {
+
+	/** @var IManager */
+	private $notificationManager;
+
+	public function __construct(IManager $notificationManager) {
+		$this->notificationManager = $notificationManager;
+	}
+
+	public function sendNotificationOnPending($userId, $target): void {
+		$notification = $this->buildScheduledNotification($userId, $target)
+			->setDateTime(new DateTime());
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendNotificationOnSuccess(ZipJob $job, File $file): void {
+		$this->notificationManager->markProcessed($this->buildScheduledNotification($job->getUid(), $job->getTarget()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('target', md5($job->getTarget()))
+			->setSubject(Notifier::TYPE_SUCCESS, ['fileid' => $file->getId(), 'name' => basename($job->getTarget()), 'path' => dirname($job->getTarget())]);
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendNotificationOnFailure(ZipJob $job): void {
+		$this->notificationManager->markProcessed($this->buildScheduledNotification($job->getUid(), $job->getTarget()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('job', (string)$job->getId())
+			->setSubject(Notifier::TYPE_FAILURE, ['target' => $job->getTarget()]);
+		$this->notificationManager->notify($notification);
+	}
+
+	private function buildScheduledNotification(string $uid, string $target): INotification {
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($uid)
+			->setApp('files_zip')
+			->setObject('target', md5($target))
+			->setSubject(Notifier::TYPE_SCHEDULED, [
+				'directory' => dirname($target),
+				'directory-name' => basename(dirname($target)),
+				'target-name' => basename($target),
+			]);
+		return $notification;
+	}
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,6 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 (function() {
 	const FilesPlugin = {
 		attach(fileList) {
-			const self = this
-
 			fileList.registerMultiSelectFileAction({
 				name: 'files_zip',
 				displayName: t('files_zip', 'Compress to zip'),


### PR DESCRIPTION
Implements https://github.com/nextcloud/files_zip/issues/2

- Implement user notifications for
  - A zip job has been scheduled
  - A zip job succeeded
  - An error occurred during zip creation
- Pick a unique filename
  - Filename.zip for a single file
  - parent-folder-name.zip for multiple files
  - Archive.zip for multiple files in the root
  - A unique name will be created with an appended number e.g. (1) if a file with the same name already exists

![2021-07-20_20-03-files_zip](https://user-images.githubusercontent.com/3404133/126379370-d7a926a0-2842-4706-b42f-60b025992327.png)

