### PR TITLE
-- No worky

### DIFF
--- a/lib/Service/ZipService.php
+++ b/lib/Service/ZipService.php
@@ -123,6 +123,8 @@ class ZipService {
 		$zip = new ZipStreamer([
 			'outstream' => $countStream,
 			'zip64' => true,
+			'compress' => 0x0008,
+			'level' => 3,
 		]);
 
 		foreach ($files as $node) {


### PR DESCRIPTION
Added 2 simple lines (hopefully in the right place);
compress > Sets compression level to DEFLATE, options are either store (no compression) and deflate according to their github. So this enables compression.
level > 3 Sets compression level to 3/SUPERFAST, It may be more useful to set this to 1 (normal compression) but as I can't code this and have quietly turned it into a forced option.. Faster is better.

I am unable to test this, as Windows nor Linux will let me compile it with the explanation up on the github. I couldn't figure out how to make simple buttons or to save variables and re-use them here, so quite honestly it's a take it or leave it kind of deal, but it should work as this is done according to their own explanations :)