### PR TITLE
Fix button labels in dialog

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 		enhancePrompt(suggestedFilename) {
 			const dialog = document.querySelector('.oc-dialog')
 			const input = dialog.querySelector('input[type=text]')
-			const buttons = dialog.querySelectorAll('button')
+			const buttons = dialog.querySelectorAll('.oc-dialog-buttonrow button')
 
 			const icon = dialog.querySelector('.ui-icon')
 			icon.parentNode.removeChild(icon)


### PR DESCRIPTION
The dialog to enter a name for the compressed file is based in a standard `OC.dialogs.prompt`, but with some adjustments, like the button labels. The adjustment relies on the whole dialog containing only two buttons (those from the button row), which was true in the past. However, [due to the accesibility fixes](https://github.com/nextcloud/server/pull/36772) the dialog now (Nextcloud >= 25.0.5, 26.0.0 and master) contains an extra button to close the dialog, which alters the expected order of the buttons to modify and causes the labels to be wrongly assigned.

To fix that the query to select the buttons to modify is restricted only to those in the button row, which behaves as expected in the whole range of supported versions ([from Nextcloud 22 to Nextcloud 27](https://github.com/nextcloud/files_zip/blob/75c11bd4ba72a9b0175250746606b7ea79e5577b/appinfo/info.xml#L17)).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Zipper-Compress-Dialog-Buttons-Before](https://github.com/nextcloud/files_zip/assets/26858233/85ca7c88-f091-4b2f-8b37-a2026e33a83e) | ![Zipper-Compress-Dialog-Buttons-After](https://github.com/nextcloud/files_zip/assets/26858233/ff20ce2e-bef8-473a-8189-981d2ef23eb2)

## How to test

- Use Nextcloud server >= 25.0.5, 26.0.0 or master
- Enable the _files_zip_ / _Zipper_ app
- Open the Files app
- Open the menu for a file
- _Compress to Zip_

### Result with this pull request

The buttons in the button row are labeled _Cancel_ and _Compress files_

### Result without this pull request

The buttons in the button row are labeled _Compress files_ and _Yes_, and the close button is labeled _Cancel_, which overflows its boundaries
