### PR TITLE
fix: drop Nextcloud 22, 23 and 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog for files_zip
 
-## 1.3.0
+## 1.4.0
+
+### Removed
+
+- Support for Nextcloud 22, 23 and 24
+
+## 1.3.0 (not released)
 
 ### Added
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Zipper</name>
 	<summary>Zip files in your Nextcloud</summary>
 	<description>Allow zipping files directly in your Nextcloud!</description>
-	<version>1.2.0</version>
+	<version>1.4.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Haertl</author>
@@ -14,6 +14,6 @@
 	<bugs>https://github.com/nextcloud/files_zip/issues</bugs>
 	<repository>https://github.com/nextcloud/files_zip.git</repository>
 	<dependencies>
-		<nextcloud min-version="22" max-version="27"/>
+		<nextcloud min-version="25" max-version="27"/>
 	</dependencies>
 </info>


### PR DESCRIPTION
We now use php 8.1 to build the release.
This is not supported on Nextcloud 22 and 23.