### PR TITLE
feat: Add "Compress to zip" action with declarative UI

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -12,5 +12,10 @@ return [
 			'url' => '/api/v1/zip',
 			'verb' => 'POST',
 		],
+		[
+			'name' => 'Zip#zipPath',
+			'url' => '/api/v1/zip-path',
+			'verb' => 'POST',
+		],
 	],
 ];

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -9,14 +9,40 @@ declare(strict_types=1);
 
 namespace OCA\FilesZip;
 
+use OCA\FilesZip\AppInfo\Application;
 use OCP\Capabilities\ICapability;
+use OCP\IL10N;
+use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
+
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+		private IL10N $l10n,
+	) {
+	}
+
 	public function getCapabilities() {
 		return [
 			'files_zip' => [
 				'apiVersion' => 'v1'
-			]
+			],
+			'client_integration' => [
+				'files_zip' => [
+					'version' => 0.1,
+					'context-menu' => [
+						[
+							'name' => $this->l10n->t('Compress to Zip'),
+							'url' => $this->urlGenerator->getWebroot() . '/ocs/v2.php/apps/files_zip/api/v1/zip-path',
+							'method' => 'POST',
+							'params' => [
+								'filePath' => '{filePath}',
+							],
+							'icon' => $this->urlGenerator->imagePath(Application::APP_NAME, 'files_zip.svg'),
+						],
+					],
+				],
+			],
 		];
 	}
 }


### PR DESCRIPTION
Fixes #347

A new endpoint was added to compress a given path to zip. A path had to be used instead of a file ID as the same file ID could belong to different paths, so just from the file ID it would not be possible to generate the path to the target zip file.

A unique path will be generated for the target zip file when the zip job is created. However, note that creating the zip file will anyway fail if the path exists once the job is executed.