### PR TITLE
Adjust to changes in Nextcloud 33

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>Zipper</name>
 	<summary>Zip files in your Nextcloud</summary>
 	<description>Allow zipping files directly in your Nextcloud!</description>
-	<version>2.3.0</version>
+	<version>3.0.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Haertl</author>
@@ -18,6 +18,6 @@
 	<bugs>https://github.com/nextcloud/files_zip/issues</bugs>
 	<repository>https://github.com/nextcloud/files_zip.git</repository>
 	<dependencies>
-		<nextcloud min-version="29" max-version="34"/>
+		<nextcloud min-version="33" max-version="34"/>
 	</dependencies>
 </info>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files_zip",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "files_zip",
-      "version": "2.3.0",
+      "version": "3.0.0",
       "license": "agpl",
       "dependencies": {
         "@mdi/svg": "^7.4.47",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mdi/svg": "^7.4.47",
         "@nextcloud/axios": "^2.5.1",
         "@nextcloud/dialogs": "^7.3.0",
-        "@nextcloud/files": "^3.12.2",
+        "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^3.0.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/router": "^3.1.0",
@@ -2631,66 +2631,6 @@
         "node": "^20 || ^22 || ^24"
       }
     },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
-      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
-      "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/auth": "^2.5.3",
-        "@nextcloud/capabilities": "^1.2.1",
-        "@nextcloud/l10n": "^3.4.1",
-        "@nextcloud/logger": "^3.0.3",
-        "@nextcloud/paths": "^3.0.0",
-        "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.3.0",
-        "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.2",
-        "webdav": "^5.9.0"
-      },
-      "engines": {
-        "node": "^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/files": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
-      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
-      "license": "AGPL-3.0-or-later",
-      "optional": true,
-      "dependencies": {
-        "@nextcloud/auth": "^2.5.3",
-        "@nextcloud/capabilities": "^1.2.1",
-        "@nextcloud/l10n": "^3.4.1",
-        "@nextcloud/logger": "^3.0.3",
-        "@nextcloud/paths": "^3.0.0",
-        "@nextcloud/router": "^3.1.0",
-        "@nextcloud/sharing": "^0.3.0",
-        "cancelable-promise": "^4.3.1",
-        "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.1",
-        "webdav": "^5.8.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      }
-    },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/sharing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/initial-state": "^3.0.0",
-        "is-svg": "^6.1.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      },
-      "optionalDependencies": {
-        "@nextcloud/files": "^3.12.0"
-      }
-    },
     "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
@@ -2786,9 +2726,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
-      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
@@ -2798,13 +2738,12 @@
         "@nextcloud/paths": "^3.0.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.3.0",
-        "cancelable-promise": "^4.3.1",
         "is-svg": "^6.1.0",
-        "typescript-event-target": "^1.1.1",
-        "webdav": "^5.8.0"
+        "typescript-event-target": "^1.1.2",
+        "webdav": "^5.9.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+        "node": "^24.0.0"
       }
     },
     "node_modules/@nextcloud/initial-state": {
@@ -2876,6 +2815,29 @@
       },
       "optionalDependencies": {
         "@nextcloud/files": "^3.12.0"
+      }
+    },
+    "node_modules/@nextcloud/sharing/node_modules/@nextcloud/files": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+      "license": "AGPL-3.0-or-later",
+      "optional": true,
+      "dependencies": {
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
+        "cancelable-promise": "^4.3.1",
+        "is-svg": "^6.1.0",
+        "typescript-event-target": "^1.1.1",
+        "webdav": "^5.8.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/stylelint-config": {
@@ -5328,7 +5290,10 @@
     },
     "node_modules/cancelable-promise": {
       "version": "4.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
+      "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001751",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mdi/svg": "^7.4.47",
     "@nextcloud/axios": "^2.5.1",
     "@nextcloud/dialogs": "^7.3.0",
-    "@nextcloud/files": "^3.12.2",
+    "@nextcloud/files": "^4.0.0",
     "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/l10n": "^3.4.1",
     "@nextcloud/router": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "files_zip",
   "description": "Compress selected files to a zip archive",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "author": "Julius Härtl <jus@bitgrid.net",
   "bugs": {
     "url": "https://github.com/nextcloud/files_zip/issues"

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -25,12 +25,12 @@
 <script setup lang="ts">
 import { ref, onMounted, useTemplateRef } from 'vue'
 import { NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
-import type { Node } from '@nextcloud/files'
+import type { INode } from '@nextcloud/files'
 import { getArchivePath } from './services'
 import { t, n } from '@nextcloud/l10n'
 
 const props = defineProps<{
-	nodes: Node[]
+	nodes: INode[]
 }>()
 
 const emit = defineEmits<{

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,14 +2,14 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { INode } from '@nextcloud/files'
+import type { IFileAction } from '@nextcloud/files'
 
-import { registerFileAction, FileAction, Permission, View } from '@nextcloud/files'
+import { registerFileAction, Permission } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
 import ZipIcon from '@mdi/svg/svg/zip-box-outline.svg?raw'
 import { action } from './services'
 
-const fileAction = new FileAction({
+const fileAction: IFileAction = {
 	id: 'files_zip',
 	order: 60,
 	iconSvgInline() {
@@ -18,20 +18,20 @@ const fileAction = new FileAction({
 	displayName() {
 		return t('files_zip', 'Compress to Zip')
 	},
-	enabled(nodes: INode[], view: View) {
+	enabled({ nodes, view }) {
 		if (view.id === 'trashbin') {
 			return false
 		}
 		return nodes.filter((node) => (node.permissions & Permission.READ) !== 0).length > 0
 	},
-	async execBatch(nodes: INode[], view: View, dir: string) {
-		const result = action(dir, nodes)
+	async execBatch({ nodes, folder }) {
+		const result = action(folder.dirname, nodes)
 		return Promise.all(nodes.map(() => result))
 	},
-	async exec(node: INode, view: View, dir: string): Promise<boolean|null> {
-		const result = action(dir, [node])
+	async exec({ nodes, folder }): Promise<boolean|null> {
+		const result = action(folder.dirname, nodes)
 		return result
 	},
-})
+}
 
 registerFileAction(fileAction)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,9 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { registerFileAction, FileAction, Node, Permission, View } from '@nextcloud/files'
+import type { INode } from '@nextcloud/files'
+
+import { registerFileAction, FileAction, Permission, View } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
 import ZipIcon from '@mdi/svg/svg/zip-box-outline.svg?raw'
 import { action } from './services'
@@ -16,17 +18,17 @@ const fileAction = new FileAction({
 	displayName() {
 		return t('files_zip', 'Compress to Zip')
 	},
-	enabled(nodes: Node[], view: View) {
+	enabled(nodes: INode[], view: View) {
 		if (view.id === 'trashbin') {
 			return false
 		}
 		return nodes.filter((node) => (node.permissions & Permission.READ) !== 0).length > 0
 	},
-	async execBatch(nodes: Node[], view: View, dir: string) {
+	async execBatch(nodes: INode[], view: View, dir: string) {
 		const result = action(dir, nodes)
 		return Promise.all(nodes.map(() => result))
 	},
-	async exec(node: Node, view: View, dir: string): Promise<boolean|null> {
+	async exec(node: INode, view: View, dir: string): Promise<boolean|null> {
 		const result = action(dir, [node])
 		return result
 	},

--- a/src/services.ts
+++ b/src/services.ts
@@ -5,7 +5,7 @@
 import axios from '@nextcloud/axios'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
-import type { Node } from '@nextcloud/files'
+import type { INode } from '@nextcloud/files'
 import { formatFileSize } from '@nextcloud/files'
 import { generateOcsUrl } from '@nextcloud/router'
 import Modal from './Modal.vue'
@@ -14,7 +14,7 @@ import { t } from '@nextcloud/l10n'
 
 const MAX_COMPRESS_SIZE = loadState('files_zip', 'max_compress_size', -1)
 
-export const getArchivePath = (nodes: Node[]) => {
+export const getArchivePath = (nodes: INode[]) => {
 	const currentDirectory = nodes[0]?.path
 	const currentDirectoryName = currentDirectory?.split('/').slice(-1).pop()
 
@@ -33,9 +33,9 @@ const compressFiles = async (fileIds: number[], target: string) => {
 	}
 }
 
-export const action = async (dir: string, nodes: Node[]) => {
+export const action = async (dir: string, nodes: INode[]) => {
 	const fileIds: number[] = nodes.map(file => file.fileid) as number[]
-	const size = nodes.reduce((carry: number, file: Node) => (file?.size ?? 0) + carry, 0)
+	const size = nodes.reduce((carry: number, file: INode) => (file?.size ?? 0) + carry, 0)
 
 	if (MAX_COMPRESS_SIZE !== -1 && (size ?? 0) > MAX_COMPRESS_SIZE) {
 		showError(t('files_zip', 'Only files up to {maxSize} can be compressed.', {


### PR DESCRIPTION
Fixes #426 

Requires #431 ~~(so keeping as a draft until that one is merged and this one rebased on master)~~

Nextcloud 33 is not compatible with @nextcloud/files v3, so @nextcloud/files v4 must be used instead.

However, @nextcloud/files v4 is not compatible with previous Nextcloud versions. Therefore the mininum required version must be adjusted.

As this is a breaking change the major version of the app is also increased.

## How  to test
- Setup Nextcloud 33 or 34
- Install _files_zip_ app
- Open Files app
- Show actions on a file, folder or a set of them

### Result with this pull request
_Compress to Zip_ is available

### Result without this pull request
_Compress to Zip_ is not available