### PR TITLE
fix: Fix success notification not shown

### DIFF
--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -37,7 +37,7 @@ class NotificationService {
 			->setApp('files_zip')
 			->setDateTime(new DateTime())
 			->setObject('target', md5($job->getTarget()))
-			->setSubject(Notifier::TYPE_SUCCESS, ['fileid' => $file->getId(), 'name' => basename($job->getTarget()), 'path' => dirname($job->getTarget())]);
+			->setSubject(Notifier::TYPE_SUCCESS, ['fileid' => (string)$file->getId(), 'name' => basename($job->getTarget()), 'path' => dirname($job->getTarget())]);
 		$this->notificationManager->notify($notification);
 	}
 


### PR DESCRIPTION
[The value of rich object parameters must be a string](https://github.com/nextcloud/server/blob/1ab09ec753f106661beadee1794b390ebec455dd/lib/private/RichObjectStrings/Validator.php#L86-L88). Otherwise the notification [can not be validated](https://github.com/nextcloud/server/blob/1ab09ec753f106661beadee1794b390ebec455dd/lib/private/Notification/Manager.php#L364-L367) and it is simply ignored (so they start to pile up in the database...).

[The value of rich object parameters must be a string since Nextcloud 31](https://github.com/nextcloud/server/commit/d0a827a68430cf716f098b0238a150c2fd9e4c83), so this seems to have happened since quite some time already... :see_no_evil: 

## How to test

- Enable the Notifications app
- Open the Files app
- Compress a file
- Force the background job (or wait for it to run)
  - Get the job id with `occ background-job:list`
  - Execute it with `occ background-job:execute {JOB_ID}`
- Open the notifications

### Result with this pull request

A `Your files have been stored as a Zip archive in {path}` notification is shown

### Result with this pull request

No `Your files have been stored as a Zip archive in {path}` notification is shown; a success notification for _files_zip_ can be seen in the _oc_notifications_ table of the database.
