### PR TITLE
fix: Do not show generic success message from file list

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -51,5 +51,7 @@ export const action = async (dir: string, nodes: INode[]) => {
 
 	await compressFiles(fileIds, dir + '/' + target)
 
-	return true
+	// compressFiles will show a success or error message as needed, so null is
+	// returned to prevent the file list from showing its own with less context.
+	return null
 }


### PR DESCRIPTION
[When an action is executed and it returns a boolean value the file list shows a generic _done_ or _failed_ message for the action](https://github.com/nextcloud/server/blob/044f4f076ec15af343fdab7259069c27ed309123/apps/files/src/utils/actionUtils.ts#L63-L72) (and the same is done for [batch actions of several files in the header](https://github.com/nextcloud/server/blob/044f4f076ec15af343fdab7259069c27ed309123/apps/files/src/components/FilesListTableHeaderActions.vue#L324-L349)). The `Compress to Zip` action only creates the background job that, later, will actually compress the files, so showing `Compress to Zip: done` can be confusing for the user if the zip is not already available. Moreover, the action shows [its own success message with more information](https://github.com/nextcloud/files_zip/blob/15388fce74c3b709f7cd20b868b0bb355b5069a8/src/services.ts#L30). Due to all that now the generic success message from the file list is no longer shown.



## How to test (scenario 1)

- Open the Files app
- Show the actions for a file using the three dots menu
- Execute `Compress to Zip`
- In the dialog that is shown, choose a name for the zip file and click `Compress`

### Result with this pull request

Only `Creating Zip archive started. We will notify you as soon as the archive is available.` message is shown

### Result without this pull request

Both `Creating Zip archive started. We will notify you as soon as the archive is available.` and `Compress to Zip: done` messages are shown



## How to test (scenario 2)

- Open the Files app
- Select two or more files/folders
- Show the batch actions for the selected files using the three dots menu in the file list header
- Execute `Compress to Zip`
- In the dialog that is shown, choose a name for the zip file and click `Compress`

### Result with this pull request

Only `Creating Zip archive started. We will notify you as soon as the archive is available.` message is shown

### Result without this pull request

Both `Creating Zip archive started. We will notify you as soon as the archive is available.` and `Compress to Zip: done` messages are shown
