### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -2,18 +2,18 @@
 # SPDX-License-Identifier: MIT
 fe1239ed98a163abbdea3e0490c85458 appstore-build-publish.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
-985f3ac7d51405c1601c742832a14120 lint-eslint.yml
+dc0ae733f35c60274937c2647c027d46 lint-eslint.yml
 4b40dd0073e16f74dd04e6d49dcc043d lint-php-cs.yml
 cfb31e47b6e9ab65e76c89b028754a4e lint-php.yml
 ab3a506506b1d7c1cea9593ecfd84366 lint-stylelint.yml
-97773e8d73758d9f1af50f7c8b82aef3 lint-typescript.yml
-28dcf55e283b85c292fea0d0b2a15a8a npm-build.yml
-8fab08ac7da700ee304af0bf3c18b3a3 phpunit-mysql.yml
-bbe9834ddb89207caf5e19d79ebb3672 phpunit-oci.yml
-256bf1dead4ef8479e9ce7433f871548 phpunit-pgsql.yml
-4ca2c2c4b1a73182667bab908e57c185 phpunit-sqlite.yml
+c5147997c7fb8ecbcd23c69705bddc86 lint-typescript.yml
+ab958fa2b07234fceab6b6d836fb7f19 npm-build.yml
+6d20bb9054bf13310aaa1bf98025b3d9 phpunit-mysql.yml
+a9366230d0b876662fb0ab124ba586af phpunit-oci.yml
+33e50146debe0922d4e176f22d949aa1 phpunit-pgsql.yml
+869cf6703da576578e5d1774aa87d837 phpunit-sqlite.yml
 d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml
-94c65e30a77686c079c6dfa54a008440 sync-workflow-templates.yml
-aff9f466debc652013b43d1a11b32a0b npm-audit-fix.yml
+b47a9fe981a7435caea92db33f5ad121 sync-workflow-templates.yml
+0dc931ec237a235370e224282608b20e npm-audit-fix.yml
 bea8a43904976fa01f1e091046541b37 release-relay.yml

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -28,7 +28,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -34,7 +34,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -28,7 +28,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -44,7 +44,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [lint-eslint.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-eslint.yml)
- 🆙 Updated [lint-typescript.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-typescript.yml)
- 🆙 Updated [npm-audit-fix.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-audit-fix.yml)
- 🆙 Updated [npm-build.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-build.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
- 🆙 Updated [phpunit-oci.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-oci.yml)
- 🆙 Updated [phpunit-pgsql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-pgsql.yml)
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)
- 🆙 Updated [sync-workflow-templates.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/sync-workflow-templates.yml)