### PR TITLE
Add secure archive compression and extraction support

### DIFF
--- a/SECURITY-DESIGN.md
+++ b/SECURITY-DESIGN.md
@@ -1,0 +1,60 @@
+# Archive security design
+
+Compression and extraction treat archive-related input as untrusted. The design deliberately prefers rejecting unusual archives or file names over weakening the security boundary.
+
+## Security invariants
+
+1. **Never extract directly to the Nextcloud data directory.**
+   Archive entries are written only through Nextcloud's public `OCP\Files` APIs.
+2. **Never call `ZipArchive::extractTo()` or `PharData::extractTo()`.**
+   Every entry is inspected first and copied individually afterwards.
+3. **Inspect and extract the same immutable temporary copy.**
+   This prevents a source archive from changing between validation and extraction.
+4. **All archive paths pass one central validator.**
+   Absolute paths, Windows drive paths, parent traversal, NUL/control bytes, invalid UTF-8 and excessive nesting are rejected.
+5. **Links and special filesystem objects are rejected.**
+   Symlinks, hardlinks, devices, FIFOs, sockets, sparse-file extensions and link metadata are not extracted.
+6. **No silent overwrite.**
+   Extraction always creates a new destination directory and compression refuses an existing archive target.
+7. **Duplicate normalized paths are rejected.**
+   Two archive entries may not resolve to the same destination path.
+8. **Resource limits are enforced before and while writing.**
+   Entry count, uncompressed size, suspicious compression ratio, temporary archive size, metadata size, destination quota and temporary disk space are bounded. Streaming code rechecks byte counts where practical.
+9. **Share permissions remain authoritative.**
+   Incoming shares that disable downloading cannot be used as extraction or compression sources.
+10. **Background jobs revalidate everything.**
+    Checks performed when scheduling are only for user experience; permissions, targets, formats and archive contents are checked again when the job executes.
+11. **External binaries have fixed absolute paths.**
+    The application never searches `$PATH` and does not accept executable paths, switches or shell fragments from user or administrator input. The 7-Zip backend uses only `/usr/bin/7z` and requires version 25.01 or newer.
+12. **External commands never pass through a shell.**
+    7-Zip operations use `proc_open()` with an argument array. Operational calls terminate switch and `@listfile` parsing with `--` and disable wildcard processing with `-spd` where applicable.
+13. **7-Zip never extracts directly to a destination directory.**
+    A 7z archive is first inspected with the technical listing. Every entry path, type and size is validated. Approved files are then requested individually through `7z x -so`; output is capped at the previously inspected size, written to a neutral temporary file, and finally copied to the validated destination through `OCP\Files`.
+14. **7-Zip never receives Nextcloud storage paths for compression.**
+    TAR, TAR.GZ and 7z creation first stages selected nodes through `OCP\Files` in a private `ITempManager` directory. The external binary only sees that controlled staging tree. The finished archive is copied back through `OCP\Files`.
+15. **Temporary storage must retain a safety reserve.**
+    Compression performs conservative free-space checks before staging and checks free space while streaming. TAR.GZ accounts for the intermediate TAR. Extraction limits the temporary immutable archive and individual 7z entry files.
+16. **Encrypted archives are fail-closed in the initial implementation.**
+    Password-protected/encrypted entries are rejected instead of prompting for or retaining secrets in a background job.
+
+## Threats covered
+
+- Zip Slip / path traversal (`../`, absolute paths, Windows drive paths)
+- Symlink and hardlink escape attacks
+- Device/FIFO/socket creation
+- Archive bombs and excessive entry counts
+- Huge TAR metadata records
+- Duplicate-path overwrite tricks
+- Quota exhaustion and temporary-disk exhaustion
+- TOCTOU changes between inspection and extraction
+- Bypass of disabled-download share permissions
+- Partial extraction after an error (the newly created extraction root is removed on failure)
+- Partial archive copies after an error (the new archive target is removed on failure)
+- Shell-command injection through archive names, file names or user-controlled executable paths
+- Option / `@listfile` injection into 7-Zip command lines
+- External-binary path traversal or link materialization into Nextcloud storage
+- 7-Zip output expanding beyond the size accepted during inspection
+
+## Intentionally unsupported
+
+The first secure implementation rejects features that are difficult to reproduce safely and consistently across storage backends, including encrypted/password-protected archives, archive links, special files, sparse TAR files and ambiguous/malformed technical listings. Compatibility can be expanded later only when the same security guarantees can be preserved.

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,10 +1,13 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 return [
 	'ocs' => [
 		[
@@ -15,6 +18,16 @@ return [
 		[
 			'name' => 'Zip#zipPath',
 			'url' => '/api/v1/zip-path',
+			'verb' => 'POST',
+		],
+		[
+			'name' => 'Archive#compress',
+			'url' => '/api/v1/archive',
+			'verb' => 'POST',
+		],
+		[
+			'name' => 'Archive#extract',
+			'url' => '/api/v1/extract',
 			'verb' => 'POST',
 		],
 	],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\FilesZip\AppInfo;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\FilesZip\ArchiveCapabilitiesState;
 use OCA\FilesZip\Capabilities;
 use OCA\FilesZip\InitialState;
 use OCA\FilesZip\Listener\LoadAdditionalListener;
@@ -30,6 +32,7 @@ class Application extends App implements IBootstrap {
 		$context->registerCapability(Capabilities::class);
 		$context->registerNotifierService(Notifier::class);
 		$context->registerInitialStateProvider(InitialState::class);
+		$context->registerInitialStateProvider(ArchiveCapabilitiesState::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/ArchiveCapabilitiesState.php
+++ b/lib/ArchiveCapabilitiesState.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip;
+
+use OCA\FilesZip\Service\SevenZipBinary;
+use OCP\AppFramework\Services\InitialStateProvider;
+
+final class ArchiveCapabilitiesState extends InitialStateProvider {
+	public function __construct(
+		private SevenZipBinary $sevenZip,
+	) {
+	}
+
+	public function getKey(): string {
+		return 'archive_capabilities';
+	}
+
+	/** @return array{sevenZipAvailable: bool, sevenZipPath: string, minimumSevenZipVersion: string} */
+	public function getData(): array {
+		return [
+			'sevenZipAvailable' => $this->sevenZip->isAvailable(),
+			'sevenZipPath' => SevenZipBinary::PATH,
+			'minimumSevenZipVersion' => SevenZipBinary::MINIMUM_VERSION,
+		];
+	}
+}

--- a/lib/BackgroundJob/ArchiveCompressJob.php
+++ b/lib/BackgroundJob/ArchiveCompressJob.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\BackgroundJob;
+
+use OCA\FilesZip\Service\ArchiveCompressionService;
+use OCA\FilesZip\Service\NotificationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\ITempManager;
+use Psr\Log\LoggerInterface;
+
+final class ArchiveCompressJob extends QueuedJob {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private ArchiveCompressionService $compressionService,
+		private NotificationService $notificationService,
+		private LoggerInterface $logger,
+		private ITempManager $tempManager,
+	) {
+		parent::__construct($timeFactory);
+	}
+
+	public function getUid(): string {
+		return $this->argument['uid'];
+	}
+
+	/** @return list<int> */
+	public function getFileIds(): array {
+		return $this->argument['fileIds'];
+	}
+
+	public function getTarget(): string {
+		return $this->argument['target'];
+	}
+
+	public function getFormat(): string {
+		return $this->argument['format'];
+	}
+
+	protected function run($argument): void {
+		try {
+			$file = $this->compressionService->compress(
+				$this->getUid(),
+				$this->getFileIds(),
+				$this->getTarget(),
+				$this->getFormat(),
+			);
+			$this->notificationService->sendArchiveCompressionSuccess($this, $file);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to create archive', [
+				'format' => $this->getFormat(),
+				'exception' => $e,
+			]);
+			$this->notificationService->sendArchiveCompressionFailure($this);
+		} finally {
+			$this->tempManager->clean();
+		}
+	}
+}

--- a/lib/BackgroundJob/ExtractJob.php
+++ b/lib/BackgroundJob/ExtractJob.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\BackgroundJob;
+
+use OCA\FilesZip\Service\ArchiveExtractionService;
+use OCA\FilesZip\Service\NotificationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use Psr\Log\LoggerInterface;
+
+final class ExtractJob extends QueuedJob {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private ArchiveExtractionService $extractionService,
+		private NotificationService $notificationService,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($timeFactory);
+	}
+
+	public function getUid(): string {
+		return $this->argument['uid'];
+	}
+
+	public function getFileId(): int {
+		return (int)$this->argument['fileId'];
+	}
+
+	public function getTarget(): string {
+		return $this->argument['target'];
+	}
+
+	protected function run($argument): void {
+		try {
+			$folder = $this->extractionService->extract($this->getUid(), $this->getFileId(), $this->getTarget());
+			$this->notificationService->sendExtractionSuccess($this, $folder);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to extract archive', [
+				'exception' => $e,
+				'fileId' => $this->getFileId(),
+				'target' => $this->getTarget(),
+			]);
+			$this->notificationService->sendExtractionFailure($this);
+		}
+	}
+}

--- a/lib/Controller/ArchiveController.php
+++ b/lib/Controller/ArchiveController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Controller;
+
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\TargetAlreadyExists;
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Exceptions\UnsupportedArchiveFormatException;
+use OCA\FilesZip\Service\ArchiveCompressionService;
+use OCA\FilesZip\Service\ArchiveExtractionService;
+use OCA\FilesZip\Service\NotificationService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+final class ArchiveController extends OCSController {
+	public function __construct(
+		IRequest $request,
+		private ArchiveExtractionService $extractionService,
+		private ArchiveCompressionService $compressionService,
+		private NotificationService $notificationService,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct('files_zip', $request);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param list<int> $fileIds
+	 */
+	public function compress(array $fileIds, string $target, string $format): DataResponse {
+		try {
+			$this->compressionService->createJob($fileIds, $target, $format);
+			return new DataResponse([]);
+		} catch (TargetAlreadyExists $e) {
+			return new DataResponse('Archive target already exists', Http::STATUS_CONFLICT);
+		} catch (UnsupportedArchiveFormatException $e) {
+			return new DataResponse($e->getMessage(), Http::STATUS_UNSUPPORTED_MEDIA_TYPE);
+		} catch (ArchiveLimitExceededException $e) {
+			return new DataResponse('Archive exceeds the configured limits', Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to schedule archive compression', ['exception' => $e]);
+			return new DataResponse('Failed to schedule archive compression', Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function extract(int $fileId, string $target): DataResponse {
+		try {
+			$this->extractionService->createExtractJob($fileId, $target);
+
+			$user = $this->userSession->getUser();
+			if ($user !== null) {
+				try {
+					$this->notificationService->sendExtractionPending($user->getUID(), $target);
+				} catch (\Throwable $notificationError) {
+					$this->logger->warning('Extraction was queued but the pending notification failed', [
+						'exception' => $notificationError,
+					]);
+				}
+			}
+
+			return new DataResponse([]);
+		} catch (UnsafeArchiveEntryException $e) {
+			return new DataResponse('Unsafe archive path', Http::STATUS_BAD_REQUEST);
+		} catch (UnsupportedArchiveFormatException $e) {
+			return new DataResponse('Unsupported archive format', Http::STATUS_UNSUPPORTED_MEDIA_TYPE);
+		} catch (ArchiveLimitExceededException $e) {
+			return new DataResponse('Archive exceeds the configured limits', Http::STATUS_REQUEST_ENTITY_TOO_LARGE);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to schedule archive extraction', ['exception' => $e]);
+			return new DataResponse('Failed to schedule archive extraction', Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/lib/Exceptions/ArchiveLimitExceededException.php
+++ b/lib/Exceptions/ArchiveLimitExceededException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Exceptions;
+
+use RuntimeException;
+
+final class ArchiveLimitExceededException extends RuntimeException {
+}

--- a/lib/Exceptions/UnsafeArchiveEntryException.php
+++ b/lib/Exceptions/UnsafeArchiveEntryException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Exceptions;
+
+use RuntimeException;
+
+final class UnsafeArchiveEntryException extends RuntimeException {
+}

--- a/lib/Exceptions/UnsupportedArchiveFormatException.php
+++ b/lib/Exceptions/UnsupportedArchiveFormatException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Exceptions;
+
+use RuntimeException;
+
+final class UnsupportedArchiveFormatException extends RuntimeException {
+}

--- a/lib/Model/ArchiveEntry.php
+++ b/lib/Model/ArchiveEntry.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Model;
+
+final readonly class ArchiveEntry {
+	public function __construct(
+		public string $sourcePath,
+		public string $path,
+		public int $size,
+		public bool $directory,
+	) {
+	}
+}

--- a/lib/Model/ArchiveFormat.php
+++ b/lib/Model/ArchiveFormat.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Model;
+
+use OCA\FilesZip\Exceptions\UnsupportedArchiveFormatException;
+
+enum ArchiveFormat: string {
+	case ZIP = 'zip';
+	case TAR = 'tar';
+	case TAR_GZ = 'tar.gz';
+	case SEVEN_ZIP = '7z';
+
+	public static function fromFilename(string $filename): self {
+		$name = strtolower($filename);
+
+		return match (true) {
+			str_ends_with($name, '.tar.gz'), str_ends_with($name, '.tgz') => self::TAR_GZ,
+			str_ends_with($name, '.tar') => self::TAR,
+			str_ends_with($name, '.zip') => self::ZIP,
+			str_ends_with($name, '.7z') => self::SEVEN_ZIP,
+			default => throw new UnsupportedArchiveFormatException('Unsupported archive format'),
+		};
+	}
+
+	public function extension(): string {
+		return match ($this) {
+			self::ZIP => '.zip',
+			self::TAR => '.tar',
+			self::TAR_GZ => '.tar.gz',
+			self::SEVEN_ZIP => '.7z',
+		};
+	}
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace OCA\FilesZip\Notification;
 
@@ -15,19 +16,21 @@ use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\UnknownNotificationException;
 
-class Notifier implements INotifier {
+final class Notifier implements INotifier {
 	public const TYPE_SCHEDULED = 'zip_scheduled';
 	public const TYPE_SUCCESS = 'zip_success';
 	public const TYPE_FAILURE = 'zip_error';
+	public const TYPE_ARCHIVE_SCHEDULED = 'archive_scheduled';
+	public const TYPE_ARCHIVE_SUCCESS = 'archive_success';
+	public const TYPE_ARCHIVE_FAILURE = 'archive_error';
+	public const TYPE_EXTRACT_SCHEDULED = 'extract_scheduled';
+	public const TYPE_EXTRACT_SUCCESS = 'extract_success';
+	public const TYPE_EXTRACT_FAILURE = 'extract_error';
 
-	/** @var IFactory */
-	protected $factory;
-	/** @var IURLGenerator */
-	protected $url;
-
-	public function __construct(IFactory $factory, IURLGenerator $urlGenerator) {
-		$this->factory = $factory;
-		$this->url = $urlGenerator;
+	public function __construct(
+		private IFactory $factory,
+		private IURLGenerator $url,
+	) {
 	}
 
 	public function getID(): string {
@@ -44,56 +47,123 @@ class Notifier implements INotifier {
 		}
 
 		$l = $this->factory->get('files_zip', $languageCode);
+		$parameters = $notification->getSubjectParameters();
 
 		switch ($notification->getSubject()) {
 			case self::TYPE_SCHEDULED:
-				$parameters = $notification->getSubjectParameters();
 				$notification->setRichSubject($l->t('A Zip archive {target} will be created.'), [
 					'target' => [
 						'type' => 'highlight',
 						'id' => $notification->getObjectId(),
 						'name' => $parameters['target-name'],
-					]
+					],
 				]);
 				break;
 			case self::TYPE_SUCCESS:
-				$parameters = $notification->getSubjectParameters();
 				$notification->setRichSubject($l->t('Your files have been stored as a Zip archive in {path}.'), [
 					'path' => [
 						'type' => 'file',
 						'id' => $parameters['fileid'],
 						'name' => $parameters['name'],
-						'path' => $parameters['path']
-					]
+						'path' => $parameters['path'],
+					],
 				]);
 				break;
 			case self::TYPE_FAILURE:
-				$parameters = $notification->getSubjectParameters();
 				$notification->setRichSubject($l->t('Creating the Zip file {path} failed.'), [
 					'path' => [
 						'type' => 'highlight',
 						'id' => $notification->getObjectId(),
 						'name' => basename($parameters['target']),
-					]
+					],
+				]);
+				break;
+			case self::TYPE_ARCHIVE_SCHEDULED:
+				$notification->setRichSubject($l->t('A {format} archive {target} will be created.'), [
+					'format' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId() . '-format',
+						'name' => strtoupper($parameters['format']),
+					],
+					'target' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => $parameters['target-name'],
+					],
+				]);
+				break;
+			case self::TYPE_ARCHIVE_SUCCESS:
+				$notification->setRichSubject($l->t('Your files have been stored as a {format} archive in {path}.'), [
+					'format' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId() . '-format',
+						'name' => strtoupper($parameters['format']),
+					],
+					'path' => [
+						'type' => 'file',
+						'id' => $parameters['fileid'],
+						'name' => $parameters['name'],
+						'path' => $parameters['path'],
+					],
+				]);
+				break;
+			case self::TYPE_ARCHIVE_FAILURE:
+				$notification->setRichSubject($l->t('Creating the {format} archive {path} failed.'), [
+					'format' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId() . '-format',
+						'name' => strtoupper($parameters['format']),
+					],
+					'path' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => basename($parameters['target']),
+					],
+				]);
+				break;
+			case self::TYPE_EXTRACT_SCHEDULED:
+				$notification->setRichSubject($l->t('The archive will be extracted to {target}.'), [
+					'target' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => $parameters['target-name'],
+					],
+				]);
+				break;
+			case self::TYPE_EXTRACT_SUCCESS:
+				$notification->setRichSubject($l->t('The archive was extracted to {path}.'), [
+					'path' => [
+						'type' => 'file',
+						'id' => $parameters['fileid'],
+						'name' => $parameters['name'],
+						'path' => $parameters['path'],
+					],
+				]);
+				break;
+			case self::TYPE_EXTRACT_FAILURE:
+				$notification->setRichSubject($l->t('Extracting the archive to {path} failed.'), [
+					'path' => [
+						'type' => 'highlight',
+						'id' => $notification->getObjectId(),
+						'name' => basename($parameters['target']),
+					],
 				]);
 				break;
 			default:
 				throw new UnknownNotificationException();
 		}
+
 		$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('files_zip', 'files_zip-dark.svg')));
 		$this->setParsedSubjectFromRichSubject($notification);
 		return $notification;
 	}
 
-	protected function setParsedSubjectFromRichSubject(INotification $notification): void {
-		$placeholders = $replacements = [];
+	private function setParsedSubjectFromRichSubject(INotification $notification): void {
+		$placeholders = [];
+		$replacements = [];
 		foreach ($notification->getRichSubjectParameters() as $placeholder => $parameter) {
 			$placeholders[] = '{' . $placeholder . '}';
-			if ($parameter['type'] === 'file') {
-				$replacements[] = $parameter['path'];
-			} else {
-				$replacements[] = $parameter['name'];
-			}
+			$replacements[] = $parameter['type'] === 'file' ? $parameter['path'] : $parameter['name'];
 		}
 
 		$notification->setParsedSubject(str_replace($placeholders, $replacements, $notification->getRichSubject()));

--- a/lib/Service/ArchiveCompressionService.php
+++ b/lib/Service/ArchiveCompressionService.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\Files_Sharing\SharedStorage;
+use OCA\FilesZip\AppInfo\Application;
+use OCA\FilesZip\BackgroundJob\ArchiveCompressJob;
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\TargetAlreadyExists;
+use OCA\FilesZip\Exceptions\UnsupportedArchiveFormatException;
+use OCA\FilesZip\Model\ArchiveFormat;
+use OCP\BackgroundJob\IJobList;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\ITempManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IAttributes;
+use OCP\Share\IShare;
+use RuntimeException;
+use Throwable;
+
+final class ArchiveCompressionService {
+	private const TEMP_DISK_RESERVE_BYTES = 268435456;
+	private const MAX_TREE_DEPTH = 64;
+
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private IUserSession $userSession,
+		private IUserManager $userManager,
+		private ITempManager $tempManager,
+		private IConfig $config,
+		private IJobList $jobList,
+		private SevenZipBinary $sevenZip,
+		private ArchivePathValidator $pathValidator,
+		private NotificationService $notificationService,
+	) {
+	}
+
+	/** @param list<int> $fileIds */
+	public function createJob(array $fileIds, string $target, string $formatValue): void {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new RuntimeException('No user session available');
+		}
+
+		$format = $this->parseCompressionFormat($formatValue);
+		$this->assertBackendAvailable($format);
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$target = $this->normalizeTarget($target, $format);
+		$this->resolveTargetParent($userFolder, $target);
+		$this->verifyAndGetNodes($userFolder, $fileIds);
+
+		$this->jobList->add(ArchiveCompressJob::class, [
+			'uid' => $user->getUID(),
+			'fileIds' => $fileIds,
+			'target' => $target,
+			'format' => $format->value,
+		]);
+		$this->notificationService->sendArchiveCompressionPending($user->getUID(), $target, $format->value);
+	}
+
+	/** @param list<int> $fileIds */
+	public function compress(string $uid, array $fileIds, string $target, string $formatValue): File {
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			throw new RuntimeException('User does not exist');
+		}
+
+		$format = $this->parseCompressionFormat($formatValue);
+		$this->assertBackendAvailable($format);
+		$this->userSession->setVolatileActiveUser($user);
+
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($uid);
+			$target = $this->normalizeTarget($target, $format);
+			[$targetParent, $targetName] = $this->resolveTargetParent($userFolder, $target);
+			$nodes = $this->verifyAndGetNodes($userFolder, $fileIds);
+
+			$estimatedBytes = $this->sumNodes($nodes);
+			$maxSize = (int)$this->config->getAppValue(Application::APP_NAME, 'max_compress_size', '-1');
+			if ($maxSize !== -1 && $estimatedBytes > $maxSize) {
+				throw new ArchiveLimitExceededException('Selected files exceed the configured compression limit');
+			}
+
+			$workDir = $this->tempManager->getTemporaryFolder('files-zip-compress');
+			if ($workDir === false) {
+				throw new RuntimeException('Unable to allocate temporary compression directory');
+			}
+			$stageDir = rtrim($workDir, '/') . '/input';
+			if (!@mkdir($stageDir, 0700)) {
+				throw new RuntimeException('Unable to create temporary staging directory');
+			}
+
+			$this->assertInitialTempCapacity($workDir, $estimatedBytes, $format);
+			$stagedBytes = 0;
+			$topLevelNames = [];
+			foreach ($nodes as $node) {
+				$name = $this->safeLocalName($node->getName());
+				if (in_array($name, $topLevelNames, true)) {
+					throw new RuntimeException('Selected nodes contain duplicate archive names');
+				}
+				$topLevelNames[] = $name;
+				$this->stageNode($node, $stageDir . '/' . $name, $workDir, $stagedBytes, $maxSize, 0);
+			}
+
+			$archivePath = $this->createArchive($workDir, $stageDir, $targetName, $topLevelNames, $format);
+			return $this->copyArchiveToNextcloud($archivePath, $targetParent, $targetName);
+		} finally {
+			$this->userSession->setVolatileActiveUser(null);
+		}
+	}
+
+	private function parseCompressionFormat(string $formatValue): ArchiveFormat {
+		$format = ArchiveFormat::tryFrom(strtolower($formatValue));
+		if ($format === null || $format === ArchiveFormat::ZIP) {
+			throw new UnsupportedArchiveFormatException('This endpoint only handles TAR, TAR.GZ and 7z compression');
+		}
+		return $format;
+	}
+
+	private function assertBackendAvailable(ArchiveFormat $format): void {
+		if (!$this->sevenZip->isAvailable()) {
+			throw new UnsupportedArchiveFormatException(
+				$format->value . ' compression requires ' . SevenZipBinary::PATH . ' >= ' . SevenZipBinary::MINIMUM_VERSION,
+			);
+		}
+	}
+
+	private function normalizeTarget(string $target, ArchiveFormat $format): string {
+		$target = $this->pathValidator->normalize(ltrim($target, '/'));
+		if (!str_ends_with(strtolower($target), $format->extension())) {
+			throw new UnsupportedArchiveFormatException('Archive filename does not match the selected format');
+		}
+		return $target;
+	}
+
+	/** @return array{0: Folder, 1: string} */
+	private function resolveTargetParent(Folder $userFolder, string $target): array {
+		$parentPath = dirname($target);
+		$targetName = basename($target);
+		$parent = $parentPath === '.' ? $userFolder : $userFolder->get($parentPath);
+		if (!$parent instanceof Folder || !$parent->isCreatable()) {
+			throw new RuntimeException('Archive destination is not writable');
+		}
+		$parent->verifyPath($targetName);
+		if ($parent->nodeExists($targetName)) {
+			throw new TargetAlreadyExists();
+		}
+		return [$parent, $targetName];
+	}
+
+	/**
+	 * @param list<int> $fileIds
+	 * @return list<Node>
+	 */
+	private function verifyAndGetNodes(Folder $userFolder, array $fileIds): array {
+		$nodes = [];
+		foreach ($fileIds as $fileId) {
+			if (!is_int($fileId)) {
+				continue;
+			}
+			$matches = $userFolder->getById($fileId);
+			if ($matches === []) {
+				continue;
+			}
+			$node = array_pop($matches);
+			if (!$node instanceof Node || !$node->isReadable()) {
+				continue;
+			}
+			if (!$this->isDownloadAllowed($node)) {
+				continue;
+			}
+			$nodes[] = $node;
+		}
+
+		if ($nodes === []) {
+			throw new NotFoundException('No readable files were selected');
+		}
+		return $nodes;
+	}
+
+	private function isDownloadAllowed(Node $node): bool {
+		$storage = $node->getStorage();
+		if (!$node->isShared() || !$storage->instanceOfStorage(SharedStorage::class) || !method_exists(IShare::class, 'getAttributes')) {
+			return true;
+		}
+
+		/** @var SharedStorage $storage */
+		$share = $storage->getShare();
+		$hasShareAttributes = $share && $share->getAttributes() instanceof IAttributes;
+		return !$hasShareAttributes || $share->getAttributes()->getAttribute('permissions', 'download') !== false;
+	}
+
+	/** @param list<Node> $nodes */
+	private function sumNodes(array $nodes): int {
+		$total = 0;
+		foreach ($nodes as $node) {
+			$size = $this->sumNode($node, 0);
+			if ($size > PHP_INT_MAX - $total) {
+				throw new ArchiveLimitExceededException('Selected files exceed the supported integer range');
+			}
+			$total += $size;
+		}
+		return $total;
+	}
+
+	private function sumNode(Node $node, int $depth): int {
+		if ($depth > self::MAX_TREE_DEPTH) {
+			throw new ArchiveLimitExceededException('Selected folder tree is nested too deeply');
+		}
+		if ($node instanceof File) {
+			return max(0, (int)$node->getSize());
+		}
+		if (!$node instanceof Folder) {
+			throw new RuntimeException('Unsupported Nextcloud node type');
+		}
+
+		$total = 0;
+		foreach ($node->getDirectoryListing() as $child) {
+			$size = $this->sumNode($child, $depth + 1);
+			if ($size > PHP_INT_MAX - $total) {
+				throw new ArchiveLimitExceededException('Selected files exceed the supported integer range');
+			}
+			$total += $size;
+		}
+		return $total;
+	}
+
+	private function assertInitialTempCapacity(string $workDir, int $inputBytes, ArchiveFormat $format): void {
+		$free = @disk_free_space($workDir);
+		if ($free === false) {
+			return;
+		}
+
+		$multiplier = $format === ArchiveFormat::TAR_GZ ? 3 : 2;
+		if ($inputBytes > intdiv(PHP_INT_MAX - self::TEMP_DISK_RESERVE_BYTES, $multiplier)) {
+			throw new ArchiveLimitExceededException('Compression request is too large for safe temporary staging');
+		}
+		$required = ($inputBytes * $multiplier) + self::TEMP_DISK_RESERVE_BYTES;
+		if ($required > $free) {
+			throw new ArchiveLimitExceededException('Not enough temporary disk space to create the archive safely');
+		}
+	}
+
+	private function safeLocalName(string $name): string {
+		if (
+			$name === ''
+			|| $name === '.'
+			|| $name === '..'
+			|| preg_match('//u', $name) !== 1
+			|| preg_match('/[\x00-\x1F\x7F]/u', $name) === 1
+			|| str_contains($name, '/')
+			|| str_contains($name, '\\')
+		) {
+			throw new RuntimeException('Selected file has an unsafe local staging name');
+		}
+		return $name;
+	}
+
+	private function stageNode(Node $node, string $destination, string $workDir, int &$stagedBytes, int $maxSize, int $depth): void {
+		if ($depth > self::MAX_TREE_DEPTH) {
+			throw new ArchiveLimitExceededException('Selected folder tree is nested too deeply');
+		}
+
+		if ($node instanceof Folder) {
+			if (file_exists($destination) || !@mkdir($destination, 0700)) {
+				throw new RuntimeException('Unable to create temporary folder');
+			}
+			foreach ($node->getDirectoryListing() as $child) {
+				$name = $this->safeLocalName($child->getName());
+				$this->stageNode($child, $destination . '/' . $name, $workDir, $stagedBytes, $maxSize, $depth + 1);
+			}
+			return;
+		}
+
+		if (!$node instanceof File) {
+			throw new RuntimeException('Unsupported Nextcloud node type');
+		}
+		if (file_exists($destination)) {
+			throw new RuntimeException('Temporary archive path collision');
+		}
+
+		$source = $node->fopen('rb');
+		$output = @fopen($destination, 'xb');
+		if ($source === false || $output === false) {
+			if (is_resource($source)) {
+				fclose($source);
+			}
+			if (is_resource($output)) {
+				fclose($output);
+			}
+			throw new RuntimeException('Unable to stage selected file');
+		}
+
+		try {
+			while (!feof($source)) {
+				$chunk = fread($source, 1048576);
+				if ($chunk === false) {
+					throw new RuntimeException('Unable to read selected file');
+				}
+				if ($chunk === '') {
+					if (feof($source)) {
+						break;
+					}
+					throw new RuntimeException('Selected file stream stalled');
+				}
+
+				$length = strlen($chunk);
+				if ($maxSize !== -1 && $length > $maxSize - $stagedBytes) {
+					throw new ArchiveLimitExceededException('Selected files exceed the configured compression limit');
+				}
+				$free = @disk_free_space($workDir);
+				if ($free !== false && $length + self::TEMP_DISK_RESERVE_BYTES > $free) {
+					throw new ArchiveLimitExceededException('Temporary disk space reserve would be exhausted');
+				}
+				$this->writeAll($output, $chunk);
+				$stagedBytes += $length;
+			}
+		} finally {
+			fclose($source);
+			fclose($output);
+		}
+	}
+
+	/** @param list<string> $topLevelNames */
+	private function createArchive(string $workDir, string $stageDir, string $targetName, array $topLevelNames, ArchiveFormat $format): string {
+		$outputPath = rtrim($workDir, '/') . '/output' . $format->extension();
+		if (file_exists($outputPath)) {
+			throw new RuntimeException('Temporary archive output already exists');
+		}
+
+		if ($format === ArchiveFormat::TAR_GZ) {
+			$tarName = preg_replace('/\.gz$/i', '', $targetName);
+			if (!is_string($tarName) || $tarName === '' || $tarName === $targetName) {
+				throw new RuntimeException('Invalid TAR.GZ target name');
+			}
+			$tarPath = rtrim($workDir, '/') . '/' . $this->safeLocalName($tarName);
+			$this->sevenZip->run([
+				'a', '-ttar', '-bd', '-bb0', '-y', '-spd', '--', $tarPath, ...$topLevelNames,
+			], $stageDir);
+			$this->sevenZip->run([
+				'a', '-tgzip', '-bd', '-bb0', '-y', '-spd', '--', $outputPath, $tarPath,
+			], $workDir);
+		} else {
+			$type = $format === ArchiveFormat::TAR ? 'tar' : '7z';
+			$this->sevenZip->run([
+				'a', '-t' . $type, '-bd', '-bb0', '-y', '-spd', '--', $outputPath, ...$topLevelNames,
+			], $stageDir);
+		}
+
+		if (!is_file($outputPath) || filesize($outputPath) === false) {
+			throw new RuntimeException('7-Zip did not create the expected archive');
+		}
+		return $outputPath;
+	}
+
+	private function copyArchiveToNextcloud(string $archivePath, Folder $targetParent, string $targetName): File {
+		$size = filesize($archivePath);
+		if ($size === false) {
+			throw new RuntimeException('Unable to determine archive size');
+		}
+		$free = $targetParent->getFreeSpace();
+		if ($free >= 0 && $size > $free) {
+			throw new ArchiveLimitExceededException('Archive does not fit in the destination quota');
+		}
+		if ($targetParent->nodeExists($targetName)) {
+			throw new TargetAlreadyExists();
+		}
+
+		$file = $targetParent->newFile($targetName);
+		$source = @fopen($archivePath, 'rb');
+		$output = $file->fopen('wb');
+		if ($source === false || $output === false) {
+			if (is_resource($source)) {
+				fclose($source);
+			}
+			if (is_resource($output)) {
+				fclose($output);
+			}
+			try {
+				$file->delete();
+			} catch (Throwable) {
+			}
+			throw new RuntimeException('Unable to write archive to Nextcloud storage');
+		}
+
+		try {
+			$copied = stream_copy_to_stream($source, $output);
+			if ($copied === false || $copied !== $size) {
+				throw new RuntimeException('Archive copy ended before all bytes were written');
+			}
+		} catch (Throwable $e) {
+			try {
+				$file->delete();
+			} catch (Throwable) {
+			}
+			throw $e;
+		} finally {
+			fclose($source);
+			fclose($output);
+		}
+
+		return $file;
+	}
+
+	/** @param resource $stream */
+	private function writeAll($stream, string $data): void {
+		$offset = 0;
+		$length = strlen($data);
+		while ($offset < $length) {
+			$written = fwrite($stream, substr($data, $offset));
+			if ($written === false || $written === 0) {
+				throw new RuntimeException('Unable to write temporary staged file');
+			}
+			$offset += $written;
+		}
+	}
+}

--- a/lib/Service/ArchiveExtractionService.php
+++ b/lib/Service/ArchiveExtractionService.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\Files_Sharing\SharedStorage;
+use OCA\FilesZip\BackgroundJob\ExtractJob;
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\UnsupportedArchiveFormatException;
+use OCA\FilesZip\Model\ArchiveEntry;
+use OCA\FilesZip\Model\ArchiveFormat;
+use OCP\BackgroundJob\IJobList;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\ITempManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IAttributes;
+use OCP\Share\IShare;
+use PharData;
+use RuntimeException;
+use Throwable;
+use ZipArchive;
+
+final class ArchiveExtractionService {
+	private const APP_ID = 'files_zip';
+	private const DEFAULT_MAX_ARCHIVE_BYTES = 5368709120;
+	private const TEMP_DISK_RESERVE_BYTES = 268435456;
+
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private IUserSession $userSession,
+		private IUserManager $userManager,
+		private ITempManager $tempManager,
+		private IConfig $config,
+		private IJobList $jobList,
+		private ArchivePathValidator $pathValidator,
+		private ExtractionWriter $writer,
+		private ZipInspector $zipInspector,
+		private TarInspector $tarInspector,
+		private SevenZipBinary $sevenZip,
+		private SevenZipInspector $sevenZipInspector,
+	) {
+	}
+
+	public function createExtractJob(int $fileId, string $target): void {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new RuntimeException('No user session available');
+		}
+
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$archive = $this->getReadableArchive($userFolder, $fileId);
+		$format = ArchiveFormat::fromFilename($archive->getName());
+		$this->assertFormatAvailable($format);
+		$this->resolveTarget($userFolder, $target);
+
+		$this->jobList->add(ExtractJob::class, [
+			'uid' => $user->getUID(),
+			'fileId' => $fileId,
+			'target' => $target,
+		]);
+	}
+
+	public function extract(string $uid, int $fileId, string $target): Folder {
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			throw new RuntimeException('User does not exist');
+		}
+
+		$this->userSession->setVolatileActiveUser($user);
+		$tempPath = null;
+		$extractionRoot = null;
+
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($uid);
+			$archive = $this->getReadableArchive($userFolder, $fileId);
+			$format = ArchiveFormat::fromFilename($archive->getName());
+			$this->assertFormatAvailable($format);
+			[$parent, $rootName] = $this->resolveTarget($userFolder, $target);
+
+			$tempPath = $this->copyArchiveToTemporaryFile($archive, $format);
+			$entries = $this->inspectArchive($tempPath, $format);
+			$this->assertDestinationCapacity($parent, $entries);
+
+			$extractionRoot = $this->writer->createExtractionRoot($parent, $rootName);
+			$this->extractEntries($tempPath, $format, $entries, $extractionRoot);
+
+			return $extractionRoot;
+		} catch (Throwable $e) {
+			if ($extractionRoot instanceof Folder) {
+				try {
+					$extractionRoot->delete();
+				} catch (Throwable) {
+					// Preserve the original extraction failure.
+				}
+			}
+			throw $e;
+		} finally {
+			if (is_string($tempPath) && is_file($tempPath)) {
+				@unlink($tempPath);
+			}
+			$this->userSession->setVolatileActiveUser(null);
+		}
+	}
+
+	private function assertFormatAvailable(ArchiveFormat $format): void {
+		if ($format === ArchiveFormat::ZIP && !class_exists(ZipArchive::class)) {
+			throw new UnsupportedArchiveFormatException('The PHP zip extension is required for ZIP extraction');
+		}
+		if (($format === ArchiveFormat::TAR || $format === ArchiveFormat::TAR_GZ) && !class_exists(PharData::class)) {
+			throw new UnsupportedArchiveFormatException('The PHP Phar extension is required for TAR extraction');
+		}
+		if ($format === ArchiveFormat::TAR_GZ && !function_exists('gzopen')) {
+			throw new UnsupportedArchiveFormatException('The PHP zlib extension is required for TAR.GZ extraction');
+		}
+		if ($format === ArchiveFormat::SEVEN_ZIP && !$this->sevenZip->isAvailable()) {
+			throw new UnsupportedArchiveFormatException('7z extraction requires ' . SevenZipBinary::PATH . ' >= ' . SevenZipBinary::MINIMUM_VERSION);
+		}
+	}
+
+	private function getReadableArchive(Folder $userFolder, int $fileId): File {
+		foreach ($userFolder->getById($fileId) as $node) {
+			if (!$node instanceof File || !$node->isReadable()) {
+				continue;
+			}
+
+			$storage = $node->getStorage();
+			if ($node->isShared() && $storage->instanceOfStorage(SharedStorage::class) && method_exists(IShare::class, 'getAttributes')) {
+				/** @var SharedStorage $storage */
+				$share = $storage->getShare();
+				$hasShareAttributes = $share && $share->getAttributes() instanceof IAttributes;
+				if ($hasShareAttributes && $share->getAttributes()->getAttribute('permissions', 'download') === false) {
+					continue;
+				}
+			}
+
+			return $node;
+		}
+
+		throw new NotFoundException('Archive not found or not readable');
+	}
+
+	/** @return array{0: Folder, 1: string} */
+	private function resolveTarget(Folder $userFolder, string $target): array {
+		$target = $this->pathValidator->normalize(ltrim($target, '/'));
+		$parentPath = dirname($target);
+		$rootName = basename($target);
+		$parent = $parentPath === '.' ? $userFolder : $userFolder->get($parentPath);
+		if (!$parent instanceof Folder) {
+			throw new RuntimeException('Extraction destination is not a folder');
+		}
+		if (!$parent->isCreatable()) {
+			throw new RuntimeException('Extraction destination is not writable');
+		}
+		if ($parent->nodeExists($rootName)) {
+			throw new RuntimeException('Extraction target already exists');
+		}
+
+		return [$parent, $rootName];
+	}
+
+	private function copyArchiveToTemporaryFile(File $archive, ArchiveFormat $format): string {
+		$maxArchiveBytes = (int)$this->config->getAppValue(
+			self::APP_ID,
+			'max_extract_archive_size',
+			(string)self::DEFAULT_MAX_ARCHIVE_BYTES,
+		);
+		$knownSize = (int)$archive->getSize();
+		if ($maxArchiveBytes !== -1 && $knownSize >= 0 && $knownSize > $maxArchiveBytes) {
+			throw new ArchiveLimitExceededException('Archive is larger than the configured extraction limit');
+		}
+
+		$tempPath = $this->tempManager->getTemporaryFile($format->extension());
+		if ($tempPath === false) {
+			throw new RuntimeException('Unable to allocate a temporary archive file');
+		}
+
+		try {
+			$diskFree = @disk_free_space(dirname($tempPath));
+			$diskLimit = false;
+			if ($diskFree !== false) {
+				$diskLimit = max(0, (int)$diskFree - self::TEMP_DISK_RESERVE_BYTES);
+				if ($knownSize >= 0 && $knownSize > $diskLimit) {
+					throw new ArchiveLimitExceededException('Not enough temporary disk space to inspect the archive');
+				}
+			}
+
+			$effectiveLimit = $maxArchiveBytes;
+			if ($diskLimit !== false && ($effectiveLimit === -1 || $diskLimit < $effectiveLimit)) {
+				$effectiveLimit = $diskLimit;
+			}
+
+			$source = $archive->fopen('rb');
+			$destination = @fopen($tempPath, 'wb');
+			if ($source === false || $destination === false) {
+				if (is_resource($source)) {
+					fclose($source);
+				}
+				if (is_resource($destination)) {
+					fclose($destination);
+				}
+				throw new RuntimeException('Unable to copy archive to temporary storage');
+			}
+
+			$total = 0;
+			try {
+				while (!feof($source)) {
+					$chunk = fread($source, 1048576);
+					if ($chunk === false) {
+						throw new RuntimeException('Unable to read archive');
+					}
+					if ($chunk === '') {
+						if (feof($source)) {
+							break;
+						}
+						throw new RuntimeException('Archive stream stalled');
+					}
+
+					$length = strlen($chunk);
+					if ($effectiveLimit !== -1 && $length > $effectiveLimit - $total) {
+						throw new ArchiveLimitExceededException('Archive exceeds the safe temporary copy limit');
+					}
+					$this->writeAll($destination, $chunk);
+					$total += $length;
+				}
+			} finally {
+				fclose($source);
+				fclose($destination);
+			}
+
+			return $tempPath;
+		} catch (Throwable $e) {
+			if (is_file($tempPath)) {
+				@unlink($tempPath);
+			}
+			throw $e;
+		}
+	}
+
+	/** @return list<ArchiveEntry> */
+	private function inspectArchive(string $tempPath, ArchiveFormat $format): array {
+		return match ($format) {
+			ArchiveFormat::ZIP => $this->inspectZip($tempPath),
+			ArchiveFormat::TAR => $this->tarInspector->inspect($tempPath, false),
+			ArchiveFormat::TAR_GZ => $this->tarInspector->inspect($tempPath, true),
+			ArchiveFormat::SEVEN_ZIP => $this->inspectSevenZip($tempPath),
+		};
+	}
+
+	/** @return list<ArchiveEntry> */
+	private function inspectZip(string $tempPath): array {
+		$zip = new ZipArchive();
+		$result = $zip->open($tempPath, ZipArchive::RDONLY);
+		if ($result !== true) {
+			throw new RuntimeException('Unable to open ZIP archive');
+		}
+		try {
+			$size = filesize($tempPath);
+			if ($size === false) {
+				throw new RuntimeException('Unable to determine ZIP archive size');
+			}
+			return $this->zipInspector->inspect($zip, $size);
+		} finally {
+			$zip->close();
+		}
+	}
+
+	/** @return list<ArchiveEntry> */
+	private function inspectSevenZip(string $tempPath): array {
+		$size = filesize($tempPath);
+		if ($size === false) {
+			throw new RuntimeException('Unable to determine 7z archive size');
+		}
+		$listing = $this->sevenZip->capture([
+			'l', '-slt', '-bd', '-sccUTF-8', '-spd', '--', $tempPath,
+		]);
+		return $this->sevenZipInspector->inspect($listing, $size);
+	}
+
+	/** @param list<ArchiveEntry> $entries */
+	private function assertDestinationCapacity(Folder $parent, array $entries): void {
+		$total = 0;
+		foreach ($entries as $entry) {
+			if ($entry->size > PHP_INT_MAX - $total) {
+				throw new ArchiveLimitExceededException('Archive size exceeds the supported integer range');
+			}
+			$total += $entry->size;
+		}
+
+		$freeSpace = $parent->getFreeSpace();
+		if ($freeSpace >= 0 && $total > $freeSpace) {
+			throw new ArchiveLimitExceededException('Archive does not fit in the destination quota');
+		}
+	}
+
+	/** @param list<ArchiveEntry> $entries */
+	private function extractEntries(string $tempPath, ArchiveFormat $format, array $entries, Folder $root): void {
+		match ($format) {
+			ArchiveFormat::ZIP => $this->extractZip($tempPath, $entries, $root),
+			ArchiveFormat::TAR, ArchiveFormat::TAR_GZ => $this->extractTar($tempPath, $entries, $root),
+			ArchiveFormat::SEVEN_ZIP => $this->extractSevenZip($tempPath, $entries, $root),
+		};
+	}
+
+	/** @param list<ArchiveEntry> $entries */
+	private function extractZip(string $tempPath, array $entries, Folder $root): void {
+		$zip = new ZipArchive();
+		$result = $zip->open($tempPath, ZipArchive::RDONLY);
+		if ($result !== true) {
+			throw new RuntimeException('Unable to reopen ZIP archive');
+		}
+
+		try {
+			foreach ($entries as $entry) {
+				if ($entry->directory) {
+					$this->writer->ensureDirectory($root, $entry->path);
+					continue;
+				}
+
+				$source = $zip->getStream($entry->sourcePath);
+				if ($source === false) {
+					throw new RuntimeException('Unable to open ZIP entry stream');
+				}
+				try {
+					$this->writer->writeFile($root, $entry->path, $source, $entry->size);
+				} finally {
+					fclose($source);
+				}
+			}
+		} finally {
+			$zip->close();
+		}
+	}
+
+	/** @param list<ArchiveEntry> $entries */
+	private function extractTar(string $tempPath, array $entries, Folder $root): void {
+		$archive = new PharData($tempPath);
+		foreach ($entries as $entry) {
+			if ($entry->directory) {
+				$this->writer->ensureDirectory($root, $entry->path);
+				continue;
+			}
+
+			if (!isset($archive[$entry->sourcePath])) {
+				throw new RuntimeException('Inspected TAR entry cannot be reopened');
+			}
+			$fileInfo = $archive[$entry->sourcePath];
+			if ($fileInfo->isDir() || $fileInfo->getSize() !== $entry->size) {
+				throw new RuntimeException('TAR entry changed between inspection and extraction');
+			}
+			$source = @fopen($fileInfo->getPathname(), 'rb');
+			if ($source === false) {
+				throw new RuntimeException('Unable to open TAR entry stream');
+			}
+			try {
+				$this->writer->writeFile($root, $entry->path, $source, $entry->size);
+			} finally {
+				fclose($source);
+			}
+		}
+	}
+
+	/** @param list<ArchiveEntry> $entries */
+	private function extractSevenZip(string $tempPath, array $entries, Folder $root): void {
+		foreach ($entries as $entry) {
+			if ($entry->directory) {
+				$this->writer->ensureDirectory($root, $entry->path);
+				continue;
+			}
+
+			$entryTemp = $this->tempManager->getTemporaryFile('.7z-entry');
+			if ($entryTemp === false) {
+				throw new RuntimeException('Unable to allocate temporary 7z entry file');
+			}
+			try {
+				$this->sevenZip->extractEntryToFile($tempPath, $entry->sourcePath, $entryTemp, $entry->size);
+				$source = @fopen($entryTemp, 'rb');
+				if ($source === false) {
+					throw new RuntimeException('Unable to reopen temporary 7z entry');
+				}
+				try {
+					$this->writer->writeFile($root, $entry->path, $source, $entry->size);
+				} finally {
+					fclose($source);
+				}
+			} finally {
+				if (is_file($entryTemp)) {
+					@unlink($entryTemp);
+				}
+			}
+		}
+	}
+
+	/** @param resource $stream */
+	private function writeAll($stream, string $data): void {
+		$offset = 0;
+		$length = strlen($data);
+		while ($offset < $length) {
+			$written = fwrite($stream, substr($data, $offset));
+			if ($written === false || $written === 0) {
+				throw new RuntimeException('Unable to write temporary archive data');
+			}
+			$offset += $written;
+		}
+	}
+}

--- a/lib/Service/ArchivePathValidator.php
+++ b/lib/Service/ArchivePathValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+
+final class ArchivePathValidator {
+	private const MAX_DEPTH = 64;
+
+	/**
+	 * Normalize an archive entry to a safe path relative to the extraction root.
+	 *
+	 * Absolute paths, Windows drive paths, control characters, invalid UTF-8 and
+	 * parent traversal are rejected.
+	 */
+	public function normalize(string $path): string {
+		if (
+			$path === ''
+			|| preg_match('//u', $path) !== 1
+			|| preg_match('/[\x00-\x1F\x7F]/u', $path) === 1
+		) {
+			throw new UnsafeArchiveEntryException('Archive entry has an invalid path');
+		}
+
+		$path = str_replace('\\', '/', $path);
+
+		if (str_starts_with($path, '/') || preg_match('/^[A-Za-z]:/', $path) === 1) {
+			throw new UnsafeArchiveEntryException('Absolute or drive-qualified archive paths are not allowed');
+		}
+
+		$segments = [];
+		foreach (explode('/', $path) as $segment) {
+			if ($segment === '' || $segment === '.') {
+				continue;
+			}
+
+			if ($segment === '..') {
+				throw new UnsafeArchiveEntryException('Archive path traversal is not allowed');
+			}
+
+			$segments[] = $segment;
+			if (count($segments) > self::MAX_DEPTH) {
+				throw new UnsafeArchiveEntryException('Archive entry is nested too deeply');
+			}
+		}
+
+		if ($segments === []) {
+			throw new UnsafeArchiveEntryException('Archive entry resolves to an empty path');
+		}
+
+		return implode('/', $segments);
+	}
+}

--- a/lib/Service/ExtractionWriter.php
+++ b/lib/Service/ExtractionWriter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use RuntimeException;
+
+final class ExtractionWriter {
+	public function __construct(
+		private ArchivePathValidator $pathValidator,
+	) {
+	}
+
+	public function createExtractionRoot(Folder $parent, string $name): Folder {
+		$name = $this->pathValidator->normalize($name);
+		if (str_contains($name, '/')) {
+			throw new UnsafeArchiveEntryException('Extraction root must be a direct child of the destination folder');
+		}
+		if (!$parent->isCreatable()) {
+			throw new RuntimeException('Destination folder is not writable');
+		}
+		$parent->verifyPath($name);
+		if ($parent->nodeExists($name)) {
+			throw new RuntimeException('Extraction target already exists');
+		}
+
+		return $parent->newFolder($name);
+	}
+
+	public function ensureDirectory(Folder $root, string $path): Folder {
+		$path = $this->pathValidator->normalize($path);
+		$current = $root;
+		foreach (explode('/', $path) as $segment) {
+			$current->verifyPath($segment);
+			if ($current->nodeExists($segment)) {
+				$node = $current->get($segment);
+				if (!$node instanceof Folder) {
+					throw new UnsafeArchiveEntryException('Archive path conflicts with an existing file');
+				}
+				$current = $node;
+				continue;
+			}
+			$current = $current->newFolder($segment);
+		}
+
+		return $current;
+	}
+
+	/** @param resource $source */
+	public function writeFile(Folder $root, string $path, $source, int $expectedSize): File {
+		$path = $this->pathValidator->normalize($path);
+		$segments = explode('/', $path);
+		$name = array_pop($segments);
+		$parent = $root;
+		if ($segments !== []) {
+			$parent = $this->ensureDirectory($root, implode('/', $segments));
+		}
+
+		$parent->verifyPath($name);
+		if ($parent->nodeExists($name)) {
+			throw new UnsafeArchiveEntryException('Archive would overwrite an existing entry');
+		}
+
+		$file = $parent->newFile($name);
+		$output = $file->fopen('wb');
+		if ($output === false) {
+			throw new RuntimeException('Unable to open extraction target for writing');
+		}
+
+		try {
+			$written = stream_copy_to_stream($source, $output, $expectedSize);
+			if ($written === false || $written !== $expectedSize) {
+				throw new RuntimeException('Archive entry ended before the expected size was written');
+			}
+		} finally {
+			fclose($output);
+		}
+
+		return $file;
+	}
+}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -1,48 +1,54 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace OCA\FilesZip\Service;
 
 use DateTime;
+use OCA\FilesZip\BackgroundJob\ArchiveCompressJob;
+use OCA\FilesZip\BackgroundJob\ExtractJob;
 use OCA\FilesZip\BackgroundJob\ZipJob;
 use OCA\FilesZip\Notification\Notifier;
 use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 
-class NotificationService {
-	/** @var IManager */
-	private $notificationManager;
-
-	public function __construct(IManager $notificationManager) {
-		$this->notificationManager = $notificationManager;
+final class NotificationService {
+	public function __construct(
+		private IManager $notificationManager,
+	) {
 	}
 
-	public function sendNotificationOnPending($userId, $target): void {
-		$notification = $this->buildScheduledNotification($userId, $target)
+	public function sendNotificationOnPending(string $userId, string $target): void {
+		$notification = $this->buildZipScheduledNotification($userId, $target)
 			->setDateTime(new DateTime());
 		$this->notificationManager->notify($notification);
 	}
 
 	public function sendNotificationOnSuccess(ZipJob $job, File $file): void {
-		$this->notificationManager->markProcessed($this->buildScheduledNotification($job->getUid(), $job->getTarget()));
+		$this->notificationManager->markProcessed($this->buildZipScheduledNotification($job->getUid(), $job->getTarget()));
 		$notification = $this->notificationManager->createNotification();
 		$notification->setUser($job->getUid())
 			->setApp('files_zip')
 			->setDateTime(new DateTime())
 			->setObject('target', md5($job->getTarget()))
-			->setSubject(Notifier::TYPE_SUCCESS, ['fileid' => (string)$file->getId(), 'name' => basename($job->getTarget()), 'path' => dirname($job->getTarget())]);
+			->setSubject(Notifier::TYPE_SUCCESS, [
+				'fileid' => (string)$file->getId(),
+				'name' => basename($job->getTarget()),
+				'path' => dirname($job->getTarget()),
+			]);
 		$this->notificationManager->notify($notification);
 	}
 
 	public function sendNotificationOnFailure(ZipJob $job): void {
-		$this->notificationManager->markProcessed($this->buildScheduledNotification($job->getUid(), $job->getTarget()));
+		$this->notificationManager->markProcessed($this->buildZipScheduledNotification($job->getUid(), $job->getTarget()));
 		$notification = $this->notificationManager->createNotification();
 		$notification->setUser($job->getUid())
 			->setApp('files_zip')
@@ -52,12 +58,107 @@ class NotificationService {
 		$this->notificationManager->notify($notification);
 	}
 
-	private function buildScheduledNotification(string $uid, string $target): INotification {
+	public function sendArchiveCompressionPending(string $userId, string $target, string $format): void {
+		$notification = $this->buildArchiveScheduledNotification($userId, $target, $format)
+			->setDateTime(new DateTime());
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendArchiveCompressionSuccess(ArchiveCompressJob $job, File $file): void {
+		$this->notificationManager->markProcessed($this->buildArchiveScheduledNotification($job->getUid(), $job->getTarget(), $job->getFormat()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('archive_target', md5($job->getTarget()))
+			->setSubject(Notifier::TYPE_ARCHIVE_SUCCESS, [
+				'fileid' => (string)$file->getId(),
+				'name' => basename($job->getTarget()),
+				'path' => dirname($job->getTarget()),
+				'format' => $job->getFormat(),
+			]);
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendArchiveCompressionFailure(ArchiveCompressJob $job): void {
+		$this->notificationManager->markProcessed($this->buildArchiveScheduledNotification($job->getUid(), $job->getTarget(), $job->getFormat()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('archive_job', (string)$job->getId())
+			->setSubject(Notifier::TYPE_ARCHIVE_FAILURE, [
+				'target' => $job->getTarget(),
+				'format' => $job->getFormat(),
+			]);
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendExtractionPending(string $userId, string $target): void {
+		$notification = $this->buildExtractScheduledNotification($userId, $target)
+			->setDateTime(new DateTime());
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendExtractionSuccess(ExtractJob $job, Folder $folder): void {
+		$this->notificationManager->markProcessed($this->buildExtractScheduledNotification($job->getUid(), $job->getTarget()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('extract_target', md5($job->getTarget()))
+			->setSubject(Notifier::TYPE_EXTRACT_SUCCESS, [
+				'fileid' => (string)$folder->getId(),
+				'name' => basename($job->getTarget()),
+				'path' => dirname($job->getTarget()),
+			]);
+		$this->notificationManager->notify($notification);
+	}
+
+	public function sendExtractionFailure(ExtractJob $job): void {
+		$this->notificationManager->markProcessed($this->buildExtractScheduledNotification($job->getUid(), $job->getTarget()));
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($job->getUid())
+			->setApp('files_zip')
+			->setDateTime(new DateTime())
+			->setObject('extract_job', (string)$job->getId())
+			->setSubject(Notifier::TYPE_EXTRACT_FAILURE, ['target' => $job->getTarget()]);
+		$this->notificationManager->notify($notification);
+	}
+
+	private function buildZipScheduledNotification(string $uid, string $target): INotification {
 		$notification = $this->notificationManager->createNotification();
 		$notification->setUser($uid)
 			->setApp('files_zip')
 			->setObject('target', md5($target))
 			->setSubject(Notifier::TYPE_SCHEDULED, [
+				'directory' => dirname($target),
+				'directory-name' => basename(dirname($target)),
+				'target-name' => basename($target),
+			]);
+		return $notification;
+	}
+
+	private function buildArchiveScheduledNotification(string $uid, string $target, string $format): INotification {
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($uid)
+			->setApp('files_zip')
+			->setObject('archive_target', md5($target))
+			->setSubject(Notifier::TYPE_ARCHIVE_SCHEDULED, [
+				'directory' => dirname($target),
+				'directory-name' => basename(dirname($target)),
+				'target-name' => basename($target),
+				'format' => $format,
+			]);
+		return $notification;
+	}
+
+	private function buildExtractScheduledNotification(string $uid, string $target): INotification {
+		$notification = $this->notificationManager->createNotification();
+		$notification->setUser($uid)
+			->setApp('files_zip')
+			->setObject('extract_target', md5($target))
+			->setSubject(Notifier::TYPE_EXTRACT_SCHEDULED, [
 				'directory' => dirname($target),
 				'directory-name' => basename(dirname($target)),
 				'target-name' => basename($target),

--- a/lib/Service/SevenZipBinary.php
+++ b/lib/Service/SevenZipBinary.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCP\ITempManager;
+use RuntimeException;
+use Throwable;
+
+final class SevenZipBinary {
+	public const PATH = '/usr/bin/7z';
+	public const MINIMUM_VERSION = '25.01';
+	private const MAX_CAPTURE_BYTES = 16777216;
+
+	public function __construct(
+		private ITempManager $tempManager,
+	) {
+	}
+
+	public function isAvailable(): bool {
+		$version = $this->getVersion();
+		return $version !== null && version_compare($version, self::MINIMUM_VERSION, '>=');
+	}
+
+	public function getVersion(): ?string {
+		if (!function_exists('proc_open') || !is_file(self::PATH) || !is_executable(self::PATH)) {
+			return null;
+		}
+
+		$descriptorSpec = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+
+		$process = @proc_open([self::PATH, 'i'], $descriptorSpec, $pipes);
+		if (!is_resource($process)) {
+			return null;
+		}
+
+		fclose($pipes[0]);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+
+		$exitCode = proc_close($process);
+		if ($exitCode !== 0) {
+			return null;
+		}
+
+		return self::parseVersion((string)$stdout . "\n" . (string)$stderr);
+	}
+
+	/** @param list<string> $arguments */
+	public function run(array $arguments, ?string $workingDirectory = null): void {
+		$this->assertRunnable($workingDirectory);
+		$this->assertArguments($arguments);
+
+		$descriptorSpec = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['file', '/dev/null', 'a'],
+			2 => ['file', '/dev/null', 'a'],
+		];
+
+		$process = @proc_open(
+			array_merge([self::PATH], $arguments),
+			$descriptorSpec,
+			$pipes,
+			$workingDirectory,
+			null,
+			['bypass_shell' => true],
+		);
+		if (!is_resource($process)) {
+			throw new RuntimeException('Unable to start 7-Zip');
+		}
+
+		$exitCode = proc_close($process);
+		if ($exitCode !== 0) {
+			throw new RuntimeException('7-Zip failed with exit code ' . $exitCode);
+		}
+	}
+
+	/**
+	 * Run a read-only 7-Zip command and return bounded stdout.
+	 *
+	 * @param list<string> $arguments
+	 */
+	public function capture(array $arguments, ?string $workingDirectory = null): string {
+		$this->assertRunnable($workingDirectory);
+		$this->assertArguments($arguments);
+
+		$stdoutPath = $this->tempManager->getTemporaryFile('.7z.stdout');
+		$stderrPath = $this->tempManager->getTemporaryFile('.7z.stderr');
+		if ($stdoutPath === false || $stderrPath === false) {
+			throw new RuntimeException('Unable to allocate temporary 7-Zip output files');
+		}
+
+		$descriptorSpec = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['file', $stdoutPath, 'w'],
+			2 => ['file', $stderrPath, 'w'],
+		];
+
+		$process = @proc_open(
+			array_merge([self::PATH], $arguments),
+			$descriptorSpec,
+			$pipes,
+			$workingDirectory,
+			null,
+			['bypass_shell' => true],
+		);
+		if (!is_resource($process)) {
+			throw new RuntimeException('Unable to start 7-Zip');
+		}
+
+		$exitCode = proc_close($process);
+		if ($exitCode !== 0) {
+			throw new RuntimeException('7-Zip inspection failed with exit code ' . $exitCode);
+		}
+
+		$size = filesize($stdoutPath);
+		if ($size === false || $size > self::MAX_CAPTURE_BYTES) {
+			throw new RuntimeException('7-Zip inspection output exceeds the safe limit');
+		}
+
+		$output = file_get_contents($stdoutPath);
+		if ($output === false) {
+			throw new RuntimeException('Unable to read 7-Zip inspection output');
+		}
+		return $output;
+	}
+
+	/**
+	 * Extract exactly one archive entry to a caller-controlled temporary file.
+	 *
+	 * 7-Zip never receives a destination directory and therefore cannot create
+	 * paths or links on the server. stdout is capped at the inspected size.
+	 */
+	public function extractEntryToFile(string $archivePath, string $entryPath, string $outputPath, int $expectedSize): void {
+		$this->assertRunnable(null);
+		if ($expectedSize < 0) {
+			throw new RuntimeException('Invalid expected 7z entry size');
+		}
+		$this->assertArguments([$archivePath, $entryPath, $outputPath]);
+
+		$descriptorSpec = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['file', '/dev/null', 'a'],
+		];
+		$command = [
+			self::PATH,
+			'x',
+			'-so',
+			'-bd',
+			'-bb0',
+			'-spd',
+			'--',
+			$archivePath,
+			$entryPath,
+		];
+		$process = @proc_open($command, $descriptorSpec, $pipes, null, null, ['bypass_shell' => true]);
+		if (!is_resource($process)) {
+			throw new RuntimeException('Unable to start 7-Zip entry extraction');
+		}
+
+		$output = @fopen($outputPath, 'wb');
+		if ($output === false) {
+			fclose($pipes[1]);
+			@proc_terminate($process);
+			@proc_close($process);
+			throw new RuntimeException('Unable to open temporary 7z entry output');
+		}
+
+		$total = 0;
+		try {
+			while (!feof($pipes[1])) {
+				$chunk = fread($pipes[1], 1048576);
+				if ($chunk === false) {
+					throw new RuntimeException('Unable to read 7-Zip entry output');
+				}
+				if ($chunk === '') {
+					if (feof($pipes[1])) {
+						break;
+					}
+					throw new RuntimeException('7-Zip entry output stalled');
+				}
+
+				$length = strlen($chunk);
+				if ($length > $expectedSize - $total) {
+					throw new RuntimeException('7-Zip produced more data than was inspected');
+				}
+				$this->writeAll($output, $chunk);
+				$total += $length;
+			}
+		} catch (Throwable $e) {
+			@proc_terminate($process);
+			fclose($pipes[1]);
+			fclose($output);
+			@proc_close($process);
+			@unlink($outputPath);
+			throw $e;
+		}
+
+		fclose($pipes[1]);
+		fclose($output);
+		$exitCode = proc_close($process);
+		if ($exitCode !== 0 || $total !== $expectedSize) {
+			@unlink($outputPath);
+			throw new RuntimeException('7-Zip entry extraction did not match inspected metadata');
+		}
+	}
+
+	private function assertRunnable(?string $workingDirectory): void {
+		if (!$this->isAvailable()) {
+			throw new RuntimeException('7-Zip ' . self::MINIMUM_VERSION . ' or newer is required at ' . self::PATH);
+		}
+		if ($workingDirectory !== null && !is_dir($workingDirectory)) {
+			throw new RuntimeException('7-Zip working directory does not exist');
+		}
+	}
+
+	/** @param list<string> $arguments */
+	private function assertArguments(array $arguments): void {
+		foreach ($arguments as $argument) {
+			if (str_contains($argument, "\0")) {
+				throw new RuntimeException('Invalid NUL byte in 7-Zip argument');
+			}
+		}
+	}
+
+	/** @param resource $stream */
+	private function writeAll($stream, string $data): void {
+		$offset = 0;
+		$length = strlen($data);
+		while ($offset < $length) {
+			$written = fwrite($stream, substr($data, $offset));
+			if ($written === false || $written === 0) {
+				throw new RuntimeException('Unable to write temporary 7-Zip output');
+			}
+			$offset += $written;
+		}
+	}
+
+	public static function parseVersion(string $output): ?string {
+		if (preg_match('/(?:7-Zip|7z)\s+([0-9]+(?:\.[0-9]+)+)/i', $output, $matches) !== 1) {
+			return null;
+		}
+
+		return $matches[1];
+	}
+}

--- a/lib/Service/SevenZipInspector.php
+++ b/lib/Service/SevenZipInspector.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Model\ArchiveEntry;
+use RuntimeException;
+
+final class SevenZipInspector {
+	public function __construct(
+		private ArchivePathValidator $pathValidator,
+		private int $maxEntries = 10000,
+		private int $maxUncompressedBytes = 10737418240,
+		private float $maxCompressionRatio = 1000.0,
+	) {
+	}
+
+	/** @return list<ArchiveEntry> */
+	public function inspect(string $technicalListing, int $archiveSize): array {
+		$blocks = $this->parseBlocks($technicalListing);
+		if (count($blocks) > $this->maxEntries) {
+			throw new ArchiveLimitExceededException('Archive contains too many entries');
+		}
+
+		$entries = [];
+		$seenPaths = [];
+		$totalSize = 0;
+
+		foreach ($blocks as $block) {
+			$sourcePath = $block['Path'] ?? null;
+			if (!is_string($sourcePath) || $sourcePath === '') {
+				throw new UnsafeArchiveEntryException('7z entry has no path');
+			}
+			if (($block['Encrypted'] ?? '-') === '+') {
+				throw new UnsafeArchiveEntryException('Encrypted archive entries are not supported');
+			}
+			foreach (['Symbolic Link', 'Hard Link', 'Copy Link'] as $linkField) {
+				if (isset($block[$linkField]) && trim($block[$linkField]) !== '') {
+					throw new UnsafeArchiveEntryException('7z links are not allowed');
+				}
+			}
+
+			$mode = trim(($block['Mode'] ?? '') . ' ' . ($block['Attributes'] ?? ''));
+			$unixType = $this->detectUnixType($mode);
+			if ($unixType !== null && $unixType !== '-' && $unixType !== 'd') {
+				throw new UnsafeArchiveEntryException('7z special file types are not allowed');
+			}
+
+			$directory = ($block['Folder'] ?? '-') === '+' || $unixType === 'd';
+			$sizeValue = $block['Size'] ?? '0';
+			if (!preg_match('/^[0-9]+$/', $sizeValue)) {
+				throw new UnsafeArchiveEntryException('7z entry has an invalid size');
+			}
+			$size = filter_var($sizeValue, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+			if ($size === false) {
+				throw new ArchiveLimitExceededException('7z entry size exceeds the supported integer range');
+			}
+			if ($directory && $size !== 0) {
+				throw new UnsafeArchiveEntryException('7z directory entry contains unexpected data');
+			}
+
+			$path = $this->pathValidator->normalize($sourcePath);
+			if (isset($seenPaths[$path])) {
+				throw new UnsafeArchiveEntryException('Duplicate archive entry path');
+			}
+			$seenPaths[$path] = true;
+
+			if ($size > $this->maxUncompressedBytes - $totalSize) {
+				throw new ArchiveLimitExceededException('Archive expands beyond the configured limit');
+			}
+			$totalSize += $size;
+			$entries[] = new ArchiveEntry($sourcePath, $path, $size, $directory);
+		}
+
+		if ($archiveSize < 0) {
+			throw new RuntimeException('Archive size is invalid');
+		}
+		if ($archiveSize > 0 && $totalSize > 1048576) {
+			$ratio = $totalSize / $archiveSize;
+			if ($ratio > $this->maxCompressionRatio) {
+				throw new ArchiveLimitExceededException('Archive compression ratio is suspiciously high');
+			}
+		}
+
+		return $entries;
+	}
+
+	/** @return list<array<string, string>> */
+	private function parseBlocks(string $output): array {
+		$lines = preg_split('/\r\n|\n|\r/', $output);
+		if ($lines === false) {
+			throw new UnsafeArchiveEntryException('Unable to parse 7z listing');
+		}
+
+		$afterSeparator = false;
+		$current = [];
+		$blocks = [];
+
+		foreach ($lines as $line) {
+			if (!$afterSeparator) {
+				if (trim($line) === '----------') {
+					$afterSeparator = true;
+				}
+				continue;
+			}
+
+			if ($line === '') {
+				if ($current !== []) {
+					$blocks[] = $current;
+					$current = [];
+				}
+				continue;
+			}
+
+			$separator = strpos($line, ' = ');
+			if ($separator === false) {
+				throw new UnsafeArchiveEntryException('Malformed 7z technical listing');
+			}
+			$key = substr($line, 0, $separator);
+			$value = substr($line, $separator + 3);
+			if ($key === '' || isset($current[$key])) {
+				throw new UnsafeArchiveEntryException('Ambiguous 7z technical listing');
+			}
+			$current[$key] = $value;
+		}
+
+		if ($current !== []) {
+			$blocks[] = $current;
+		}
+		if (!$afterSeparator) {
+			throw new UnsafeArchiveEntryException('7z listing does not contain an entry section');
+		}
+		return $blocks;
+	}
+
+	private function detectUnixType(string $metadata): ?string {
+		if (preg_match('/(?:^|\s)([bcdlps-])[rwxStTs-]{9}(?:\s|$)/', $metadata, $matches) !== 1) {
+			return null;
+		}
+		return $matches[1];
+	}
+}

--- a/lib/Service/TarInspector.php
+++ b/lib/Service/TarInspector.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Model\ArchiveEntry;
+use RuntimeException;
+
+final class TarInspector {
+	private const BLOCK_SIZE = 512;
+	private const MAX_METADATA_BYTES = 1048576;
+
+	public function __construct(
+		private ArchivePathValidator $pathValidator,
+		private int $maxEntries = 10000,
+		private int $maxUncompressedBytes = 10737418240,
+	) {
+	}
+
+	/** @return list<ArchiveEntry> */
+	public function inspect(string $archivePath, bool $gzip): array {
+		$stream = $gzip ? @gzopen($archivePath, 'rb') : @fopen($archivePath, 'rb');
+		if ($stream === false) {
+			throw new RuntimeException('Unable to open TAR archive');
+		}
+
+		try {
+			return $this->inspectStream($stream, $gzip);
+		} finally {
+			$gzip ? gzclose($stream) : fclose($stream);
+		}
+	}
+
+	/**
+	 * @param resource $stream
+	 * @return list<ArchiveEntry>
+	 */
+	private function inspectStream($stream, bool $gzip): array {
+		$entries = [];
+		$seenPaths = [];
+		$totalSize = 0;
+		$pendingLongName = null;
+		$pendingPax = [];
+
+		while (true) {
+			$header = $this->readExact($stream, self::BLOCK_SIZE, $gzip);
+			if ($header === '') {
+				break;
+			}
+			if (strlen($header) !== self::BLOCK_SIZE) {
+				throw new UnsafeArchiveEntryException('Truncated TAR header');
+			}
+			if ($header === str_repeat("\0", self::BLOCK_SIZE)) {
+				break;
+			}
+
+			$this->verifyChecksum($header);
+
+			$name = rtrim(substr($header, 0, 100), "\0");
+			$prefix = rtrim(substr($header, 345, 155), "\0");
+			if ($prefix !== '') {
+				$name = $prefix . '/' . $name;
+			}
+
+			$type = substr($header, 156, 1);
+			$size = $this->parseNumber(substr($header, 124, 12));
+
+			if ($type === 'x' || $type === 'g' || $type === 'L' || $type === 'K') {
+				if ($size > self::MAX_METADATA_BYTES) {
+					throw new ArchiveLimitExceededException('TAR metadata entry is too large');
+				}
+				$data = $this->readPaddedData($stream, $size, $gzip);
+
+				if ($type === 'x') {
+					if ($pendingPax !== []) {
+						throw new UnsafeArchiveEntryException('Multiple pending PAX headers are not allowed');
+					}
+					$pendingPax = $this->parsePax($data);
+					$this->assertSafePax($pendingPax);
+				} elseif ($type === 'g') {
+					$global = $this->parsePax($data);
+					if (isset($global['path']) || isset($global['linkpath'])) {
+						throw new UnsafeArchiveEntryException('Global PAX path metadata is not allowed');
+					}
+				} elseif ($type === 'L') {
+					if ($pendingLongName !== null) {
+						throw new UnsafeArchiveEntryException('Multiple pending GNU long names are not allowed');
+					}
+					$pendingLongName = rtrim($data, "\0\r\n");
+				} else {
+					throw new UnsafeArchiveEntryException('GNU long link entries are not allowed');
+				}
+				continue;
+			}
+
+			if (isset($pendingPax['path'])) {
+				$name = $pendingPax['path'];
+			} elseif ($pendingLongName !== null) {
+				$name = $pendingLongName;
+			}
+
+			if (isset($pendingPax['size'])) {
+				if (!ctype_digit($pendingPax['size'])) {
+					throw new UnsafeArchiveEntryException('Invalid PAX size');
+				}
+				$size = $this->decimalToInt($pendingPax['size']);
+			}
+
+			$pendingPax = [];
+			$pendingLongName = null;
+
+			$directory = $type === '5';
+			$regular = $type === "\0" || $type === '0';
+			if (!$directory && !$regular) {
+				throw new UnsafeArchiveEntryException('TAR links and special file types are not allowed');
+			}
+
+			$path = $this->pathValidator->normalize($name);
+			if (isset($seenPaths[$path])) {
+				throw new UnsafeArchiveEntryException('Duplicate archive entry path');
+			}
+			$seenPaths[$path] = true;
+
+			if (count($entries) >= $this->maxEntries) {
+				throw new ArchiveLimitExceededException('Archive contains too many entries');
+			}
+
+			if ($directory && $size !== 0) {
+				throw new UnsafeArchiveEntryException('Directory entry contains unexpected data');
+			}
+
+			if ($size > $this->maxUncompressedBytes - $totalSize) {
+				throw new ArchiveLimitExceededException('Archive expands beyond the configured limit');
+			}
+			$totalSize += $size;
+			$entries[] = new ArchiveEntry($name, $path, $size, $directory);
+
+			$this->skipPaddedData($stream, $size, $gzip);
+		}
+
+		if ($pendingLongName !== null || $pendingPax !== []) {
+			throw new UnsafeArchiveEntryException('Dangling TAR metadata entry');
+		}
+
+		return $entries;
+	}
+
+	private function verifyChecksum(string $header): void {
+		$stored = $this->parseOctal(substr($header, 148, 8));
+		$checksumHeader = substr_replace($header, str_repeat(' ', 8), 148, 8);
+		$calculated = array_sum(unpack('C*', $checksumHeader));
+		if ($stored !== $calculated) {
+			throw new UnsafeArchiveEntryException('Invalid TAR header checksum');
+		}
+	}
+
+	private function parseNumber(string $field): int {
+		if ((ord($field[0]) & 0x80) !== 0) {
+			$bytes = array_values(unpack('C*', $field));
+			$bytes[0] &= 0x7f;
+			$value = 0;
+			foreach ($bytes as $byte) {
+				if ($value > intdiv(PHP_INT_MAX - $byte, 256)) {
+					throw new ArchiveLimitExceededException('TAR numeric value is too large');
+				}
+				$value = ($value * 256) + $byte;
+			}
+			return $value;
+		}
+
+		return $this->parseOctal($field);
+	}
+
+	private function parseOctal(string $field): int {
+		$value = trim($field, " \0");
+		if ($value === '') {
+			return 0;
+		}
+		if (preg_match('/^[0-7]+$/', $value) !== 1) {
+			throw new UnsafeArchiveEntryException('Invalid TAR numeric field');
+		}
+
+		$result = 0;
+		foreach (str_split($value) as $digit) {
+			$n = ord($digit) - 48;
+			if ($result > intdiv(PHP_INT_MAX - $n, 8)) {
+				throw new ArchiveLimitExceededException('TAR numeric value is too large');
+			}
+			$result = ($result * 8) + $n;
+		}
+		return $result;
+	}
+
+	private function decimalToInt(string $value): int {
+		$result = 0;
+		foreach (str_split($value) as $digit) {
+			$n = ord($digit) - 48;
+			if ($result > intdiv(PHP_INT_MAX - $n, 10)) {
+				throw new ArchiveLimitExceededException('PAX numeric value is too large');
+			}
+			$result = ($result * 10) + $n;
+		}
+		return $result;
+	}
+
+	/** @param array<string, string> $pax */
+	private function assertSafePax(array $pax): void {
+		if (isset($pax['linkpath'])) {
+			throw new UnsafeArchiveEntryException('PAX link metadata is not allowed');
+		}
+
+		foreach (array_keys($pax) as $key) {
+			if (str_starts_with($key, 'GNU.sparse') || $key === 'SCHILY.realsize') {
+				throw new UnsafeArchiveEntryException('Sparse TAR entries are not allowed');
+			}
+		}
+	}
+
+	/** @return array<string, string> */
+	private function parsePax(string $data): array {
+		$result = [];
+		$offset = 0;
+		$length = strlen($data);
+
+		while ($offset < $length) {
+			$space = strpos($data, ' ', $offset);
+			if ($space === false) {
+				throw new UnsafeArchiveEntryException('Invalid PAX record');
+			}
+			$lengthText = substr($data, $offset, $space - $offset);
+			if ($lengthText === '' || !ctype_digit($lengthText)) {
+				throw new UnsafeArchiveEntryException('Invalid PAX record length');
+			}
+			$recordLength = $this->decimalToInt($lengthText);
+			if ($recordLength <= ($space - $offset + 1) || $offset + $recordLength > $length) {
+				throw new UnsafeArchiveEntryException('Invalid PAX record bounds');
+			}
+
+			$record = substr($data, $space + 1, $recordLength - ($space - $offset + 1));
+			if (!str_ends_with($record, "\n")) {
+				throw new UnsafeArchiveEntryException('Invalid PAX record terminator');
+			}
+			$record = substr($record, 0, -1);
+			$equals = strpos($record, '=');
+			if ($equals === false) {
+				throw new UnsafeArchiveEntryException('Invalid PAX key/value record');
+			}
+			$key = substr($record, 0, $equals);
+			$value = substr($record, $equals + 1);
+			$result[$key] = $value;
+			$offset += $recordLength;
+		}
+
+		return $result;
+	}
+
+	/** @param resource $stream */
+	private function readPaddedData($stream, int $size, bool $gzip): string {
+		$data = $this->readExact($stream, $size, $gzip);
+		if (strlen($data) !== $size) {
+			throw new UnsafeArchiveEntryException('Truncated TAR metadata entry');
+		}
+		$this->skipPadding($stream, $size, $gzip);
+		return $data;
+	}
+
+	/** @param resource $stream */
+	private function skipPaddedData($stream, int $size, bool $gzip): void {
+		$this->skipExact($stream, $size, $gzip);
+		$this->skipPadding($stream, $size, $gzip);
+	}
+
+	/** @param resource $stream */
+	private function skipPadding($stream, int $size, bool $gzip): void {
+		$padding = (self::BLOCK_SIZE - ($size % self::BLOCK_SIZE)) % self::BLOCK_SIZE;
+		$this->skipExact($stream, $padding, $gzip);
+	}
+
+	/** @param resource $stream */
+	private function skipExact($stream, int $bytes, bool $gzip): void {
+		$remaining = $bytes;
+		while ($remaining > 0) {
+			$chunk = $this->readExact($stream, min($remaining, 65536), $gzip);
+			if ($chunk === '') {
+				throw new UnsafeArchiveEntryException('Truncated TAR entry');
+			}
+			$remaining -= strlen($chunk);
+		}
+	}
+
+	/** @param resource $stream */
+	private function readExact($stream, int $bytes, bool $gzip): string {
+		if ($bytes === 0) {
+			return '';
+		}
+
+		$data = '';
+		while (strlen($data) < $bytes) {
+			$remaining = $bytes - strlen($data);
+			$chunk = $gzip ? gzread($stream, $remaining) : fread($stream, $remaining);
+			if ($chunk === false || $chunk === '') {
+				break;
+			}
+			$data .= $chunk;
+		}
+		return $data;
+	}
+}

--- a/lib/Service/ZipInspector.php
+++ b/lib/Service/ZipInspector.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Service;
+
+use OCA\FilesZip\Exceptions\ArchiveLimitExceededException;
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Model\ArchiveEntry;
+use RuntimeException;
+use ZipArchive;
+
+final class ZipInspector {
+	private const UNIX_OPSYS = 3;
+	private const UNIX_TYPE_MASK = 0170000;
+	private const UNIX_REGULAR = 0100000;
+	private const UNIX_DIRECTORY = 0040000;
+
+	public function __construct(
+		private ArchivePathValidator $pathValidator,
+		private int $maxEntries = 10000,
+		private int $maxUncompressedBytes = 10737418240,
+		private float $maxCompressionRatio = 1000.0,
+	) {
+	}
+
+	/** @return list<ArchiveEntry> */
+	public function inspect(ZipArchive $zip, int $archiveSize): array {
+		if ($zip->numFiles > $this->maxEntries) {
+			throw new ArchiveLimitExceededException('Archive contains too many entries');
+		}
+
+		$entries = [];
+		$seenPaths = [];
+		$totalSize = 0;
+
+		for ($index = 0; $index < $zip->numFiles; $index++) {
+			$stat = $zip->statIndex($index);
+			if ($stat === false || !isset($stat['name'], $stat['size'])) {
+				throw new UnsafeArchiveEntryException('Unable to inspect ZIP entry');
+			}
+
+			$name = (string)$stat['name'];
+			$size = (int)$stat['size'];
+			if ($size < 0) {
+				throw new UnsafeArchiveEntryException('ZIP entry has an invalid size');
+			}
+
+			$directory = str_ends_with($name, '/');
+			$opsys = 0;
+			$attributes = 0;
+			if ($zip->getExternalAttributesIndex($index, $opsys, $attributes) && $opsys === self::UNIX_OPSYS) {
+				$mode = ($attributes >> 16) & 0xffff;
+				$type = $mode & self::UNIX_TYPE_MASK;
+				if ($type !== 0 && $type !== self::UNIX_REGULAR && $type !== self::UNIX_DIRECTORY) {
+					throw new UnsafeArchiveEntryException('ZIP links and special file types are not allowed');
+				}
+				$directory = $directory || $type === self::UNIX_DIRECTORY;
+			}
+
+			$path = $this->pathValidator->normalize($name);
+			if (isset($seenPaths[$path])) {
+				throw new UnsafeArchiveEntryException('Duplicate archive entry path');
+			}
+			$seenPaths[$path] = true;
+
+			if ($directory && $size !== 0) {
+				throw new UnsafeArchiveEntryException('Directory entry contains unexpected data');
+			}
+
+			if ($size > $this->maxUncompressedBytes - $totalSize) {
+				throw new ArchiveLimitExceededException('Archive expands beyond the configured limit');
+			}
+			$totalSize += $size;
+			$entries[] = new ArchiveEntry($name, $path, $size, $directory);
+		}
+
+		if ($archiveSize < 0) {
+			throw new RuntimeException('Archive size is invalid');
+		}
+		if ($archiveSize > 0 && $totalSize > 1048576) {
+			$ratio = $totalSize / $archiveSize;
+			if ($ratio > $this->maxCompressionRatio) {
+				throw new ArchiveLimitExceededException('Archive compression ratio is suspiciously high');
+			}
+		}
+
+		return $entries;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/vue": "^9.10.0",
-        "@rollup/rollup-darwin-arm64": "4.63.0",
         "vue": "^3.5.41"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/vue": "^9.10.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
         "vue": "^3.5.41"
       },
       "devDependencies": {

--- a/src/CompressFilesModal.vue
+++ b/src/CompressFilesModal.vue
@@ -1,5 +1,6 @@
 <!--
  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ - SPDX-FileCopyrightText: 2026 Happyfeet01
  - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
@@ -15,7 +16,17 @@
 		</template>
 		<div class="zip-dialog">
 			<p>{{ n('files_zip', 'Compress %n file', 'Compress %n files', nodes.length) }}</p>
-			<p>{{ t('files_zip', 'The file will be compressed in the background. Once finished you will receive a notification and the file is located in the current directory.') }}</p>
+			<p>{{ t('files_zip', 'The archive will be created in the background. Once finished you will receive a notification and the file is located in the current directory.') }}</p>
+
+			<label class="format-label" for="files-zip-format">
+				{{ t('files_zip', 'Archive format') }}
+			</label>
+			<select id="files-zip-format" v-model="format" class="format-select">
+				<option v-for="option in formatOptions" :key="option.value" :value="option.value">
+					{{ option.label }}
+				</option>
+			</select>
+
 			<NcTextField
 				ref="filenameInput"
 				v-model="filename"
@@ -26,23 +37,43 @@
 
 <script setup lang="ts">
 import type { INode } from '@nextcloud/files'
+import type { ArchiveCompressionFormat, CompressionDialogResult } from './services.ts'
 
 import { n, t } from '@nextcloud/l10n'
 import { NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
-import { onMounted, ref, useTemplateRef } from 'vue'
-import { getArchivePath } from './services.ts'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { ARCHIVE_CAPABILITIES, getArchivePath, replaceArchiveExtension } from './services.ts'
 
 const props = defineProps<{
 	nodes: INode[]
 }>()
 
 const emit = defineEmits<{
-	close: [value: string | null]
+	close: [value: CompressionDialogResult | null]
 }>()
 
 const showDialog = ref(true)
-const filename = ref(getArchivePath(props.nodes))
+const format = ref<ArchiveCompressionFormat>('zip')
+const filename = ref(getArchivePath(props.nodes, format.value))
 const filenameInput = useTemplateRef('filenameInput')
+
+const formatOptions = computed<Array<{ value: ArchiveCompressionFormat, label: string }>>(() => {
+	const options: Array<{ value: ArchiveCompressionFormat, label: string }> = [
+		{ value: 'zip', label: 'ZIP' },
+	]
+	if (ARCHIVE_CAPABILITIES.sevenZipAvailable) {
+		options.push(
+			{ value: 'tar', label: 'TAR' },
+			{ value: 'tar.gz', label: 'TAR.GZ' },
+			{ value: '7z', label: '7z' },
+		)
+	}
+	return options
+})
+
+watch(format, (newFormat) => {
+	filename.value = replaceArchiveExtension(filename.value, newFormat)
+})
 
 onMounted(() => {
 	const input = filenameInput.value?.$refs?.inputField?.$refs?.input
@@ -52,17 +83,14 @@ onMounted(() => {
 	}
 })
 
-/**
- *
- */
 function saveFile(): void {
 	showDialog.value = false
-	emit('close', filename.value)
+	emit('close', {
+		filename: filename.value,
+		format: format.value,
+	})
 }
 
-/**
- *
- */
 function handleClosing() {
 	emit('close', null)
 }
@@ -75,5 +103,22 @@ function handleClosing() {
 
 p {
 	margin-bottom: 12px;
+}
+
+.format-label {
+	display: block;
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+.format-select {
+	width: 100%;
+	min-height: 44px;
+	margin-bottom: 12px;
+	padding: 0 12px;
+	border: 2px solid var(--color-border-maxcontrast);
+	border-radius: var(--border-radius-large);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
 }
 </style>

--- a/src/ExtractArchiveModal.vue
+++ b/src/ExtractArchiveModal.vue
@@ -1,0 +1,73 @@
+<!--
+ - SPDX-FileCopyrightText: 2026 Happyfeet01
+ - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcDialog
+		v-if="showDialog"
+		:name="t('files_zip', 'Extract archive')"
+		contentClasses="extract-dialog"
+		@closing="handleClosing">
+		<template #actions>
+			<NcButton variant="primary" @click="extract">
+				{{ t('files_zip', 'Extract') }}
+			</NcButton>
+		</template>
+		<div class="extract-dialog">
+			<p>{{ t('files_zip', 'The archive will be checked and extracted in the background.') }}</p>
+			<p>{{ t('files_zip', 'Existing files are never overwritten. Unsafe archive entries are rejected.') }}</p>
+			<NcTextField
+				ref="targetInput"
+				v-model="target"
+				:label="t('files_zip', 'New folder name')" />
+		</div>
+	</NcDialog>
+</template>
+
+<script setup lang="ts">
+import type { INode } from '@nextcloud/files'
+
+import { t } from '@nextcloud/l10n'
+import { NcButton, NcDialog, NcTextField } from '@nextcloud/vue'
+import { onMounted, ref, useTemplateRef } from 'vue'
+import { getExtractTarget } from './services.ts'
+
+const props = defineProps<{
+	node: INode
+}>()
+
+const emit = defineEmits<{
+	close: [value: string | null]
+}>()
+
+const showDialog = ref(true)
+const target = ref(getExtractTarget(props.node))
+const targetInput = useTemplateRef('targetInput')
+
+onMounted(() => {
+	const input = targetInput.value?.$refs?.inputField?.$refs?.input
+	input?.focus()
+})
+
+function extract(): void {
+	if (target.value.trim() === '') {
+		return
+	}
+	showDialog.value = false
+	emit('close', target.value.trim())
+}
+
+function handleClosing() {
+	emit('close', null)
+}
+</script>
+
+<style lang="scss" scoped>
+.extract-dialog {
+	margin: 12px;
+}
+
+p {
+	margin-bottom: 12px;
+}
+</style>

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,8 @@
 /**
- * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 import { getLoggerBuilder } from '@nextcloud/logger'
 
 export const logger = getLoggerBuilder()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { IFileAction } from '@nextcloud/files'
@@ -7,9 +8,9 @@ import type { IFileAction } from '@nextcloud/files'
 import ZipIcon from '@mdi/svg/svg/zip-box-outline.svg?raw'
 import { Permission, registerFileAction } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
-import { action } from './services.ts'
+import { action, extractAction, isExtractableArchive } from './services.ts'
 
-const fileAction: IFileAction = {
+const compressAction: IFileAction = {
 	id: 'files_zip',
 	order: 60,
 	iconSvgInline() {
@@ -25,13 +26,44 @@ const fileAction: IFileAction = {
 		return nodes.filter((node) => (node.permissions & Permission.READ) !== 0).length > 0
 	},
 	async execBatch({ nodes, folder }) {
-		const result = action(folder.dirname, nodes)
+		const result = action(folder.path, nodes)
 		return Promise.all(nodes.map(() => result))
 	},
 	async exec({ nodes, folder }): Promise<boolean | null> {
-		const result = action(folder.dirname, nodes)
-		return result
+		return action(folder.path, nodes)
 	},
 }
 
-registerFileAction(fileAction)
+const extractFileAction: IFileAction = {
+	id: 'files_zip_extract',
+	order: 61,
+	iconSvgInline() {
+		return ZipIcon
+	},
+	displayName() {
+		return t('files_zip', 'Extract archive')
+	},
+	enabled({ nodes, view }) {
+		if (view.id === 'trashbin' || nodes.length !== 1) {
+			return false
+		}
+		const node = nodes[0]
+		return (node.permissions & Permission.READ) !== 0 && isExtractableArchive(node)
+	},
+	async execBatch({ nodes, folder }) {
+		if (nodes.length !== 1) {
+			return Promise.all(nodes.map(async () => false))
+		}
+		const result = extractAction(folder.path, nodes[0])
+		return Promise.all(nodes.map(() => result))
+	},
+	async exec({ nodes, folder }): Promise<boolean | null> {
+		if (nodes.length !== 1) {
+			return false
+		}
+		return extractAction(folder.path, nodes[0])
+	},
+}
+
+registerFileAction(compressAction)
+registerFileAction(extractFileAction)

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,5 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { INode } from '@nextcloud/files'
@@ -12,45 +13,98 @@ import { t } from '@nextcloud/l10n'
 import { generateOcsUrl } from '@nextcloud/router'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import CompressFilesModal from './CompressFilesModal.vue'
+import ExtractArchiveModal from './ExtractArchiveModal.vue'
 import { logger } from './logger.ts'
 
 const MAX_COMPRESS_SIZE = loadState('files_zip', 'max_compress_size', -1)
 
-/**
- *
- * @param nodes the nodes to be compressed
- */
-export function getArchivePath(nodes: INode[]) {
+export interface ArchiveCapabilities {
+	sevenZipAvailable: boolean
+	sevenZipPath: string
+	minimumSevenZipVersion: string
+}
+
+export const ARCHIVE_CAPABILITIES = loadState<ArchiveCapabilities>('files_zip', 'archive_capabilities', {
+	sevenZipAvailable: false,
+	sevenZipPath: '/usr/bin/7z',
+	minimumSevenZipVersion: '25.01',
+})
+
+export type ArchiveCompressionFormat = 'zip' | 'tar' | 'tar.gz' | '7z'
+
+export interface CompressionDialogResult {
+	filename: string
+	format: ArchiveCompressionFormat
+}
+
+export function archiveExtension(format: ArchiveCompressionFormat): string {
+	return format === 'tar.gz' ? '.tar.gz' : `.${format}`
+}
+
+export function replaceArchiveExtension(filename: string, format: ArchiveCompressionFormat): string {
+	const base = filename.replace(/(?:\.tar\.gz|\.tgz|\.zip|\.tar|\.7z)$/i, '') || t('files_zip', 'Archive')
+	return base + archiveExtension(format)
+}
+
+export function getArchivePath(nodes: INode[], format: ArchiveCompressionFormat = 'zip') {
 	const currentDirectory = nodes[0]?.path
 	const currentDirectoryName = currentDirectory?.split('/').slice(-1).pop()
 
-	return (currentDirectoryName ?? t('files_zip', 'Archive')) + '.zip'
+	return (currentDirectoryName ?? t('files_zip', 'Archive')) + archiveExtension(format)
 }
 
-/**
- *
- * @param fileIds the ids of the files to compress
- * @param target the path to the compressed file
- */
-async function compressFiles(fileIds: number[], target: string) {
-	try {
-		await axios.post(generateOcsUrl('apps/files_zip/api/v1/zip'), {
-			fileIds,
-			target,
-		})
-		showSuccess(t('files_zip', 'Creating Zip archive started. We will notify you as soon as the archive is available.'))
-	} catch (error) {
-		logger.error('Error when compressing the file', { error })
+export function getExtractTarget(node: INode): string {
+	return node.basename
+		.replace(/\.tar\.gz$/i, '')
+		.replace(/\.tgz$/i, '')
+		.replace(/\.(zip|tar|7z)$/i, '')
+}
 
-		showError(t('files_zip', 'An error happened when trying to compress the file.'))
+export function isExtractableArchive(node: INode): boolean {
+	const name = node.basename.toLowerCase()
+	return name.endsWith('.zip')
+		|| name.endsWith('.tar')
+		|| name.endsWith('.tar.gz')
+		|| name.endsWith('.tgz')
+		|| (ARCHIVE_CAPABILITIES.sevenZipAvailable && name.endsWith('.7z'))
+}
+
+async function compressFiles(fileIds: number[], target: string, format: ArchiveCompressionFormat) {
+	try {
+		if (format === 'zip') {
+			await axios.post(generateOcsUrl('apps/files_zip/api/v1/zip'), {
+				fileIds,
+				target,
+			})
+		} else {
+			await axios.post(generateOcsUrl('apps/files_zip/api/v1/archive'), {
+				fileIds,
+				target,
+				format,
+			})
+		}
+		showSuccess(t('files_zip', 'Creating {format} archive started. We will notify you as soon as the archive is available.', {
+			format: format.toUpperCase(),
+		}))
+	} catch (error) {
+		logger.error('Error when compressing the file', { error, format })
+		showError(t('files_zip', 'An error happened when trying to create the archive.'))
 	}
 }
 
-/**
- *
- * @param dir the name of the working directory
- * @param nodes the nodes to be compressed
- */
+async function extractArchive(fileId: number, target: string) {
+	try {
+		await axios.post(generateOcsUrl('apps/files_zip/api/v1/extract'), {
+			fileId,
+			target,
+		})
+		showSuccess(t('files_zip', 'Archive extraction started. Unsafe entries will be rejected.'))
+	} catch (error) {
+		logger.error('Error when scheduling archive extraction', { error })
+		showError(t('files_zip', 'The archive could not be scheduled for extraction.'))
+	}
+}
+
 export async function action(dir: string, nodes: INode[]) {
 	const fileIds: number[] = nodes.map((file) => file.fileid) as number[]
 	const size = nodes.reduce((carry: number, file: INode) => (file?.size ?? 0) + carry, 0)
@@ -62,14 +116,21 @@ export async function action(dir: string, nodes: INode[]) {
 		return null
 	}
 
-	const target = await spawnDialog(CompressFilesModal, { nodes })
+	const result = await spawnDialog(CompressFilesModal, { nodes }) as CompressionDialogResult | null
+	if (result === null) {
+		return null
+	}
+
+	await compressFiles(fileIds, dir + '/' + result.filename, result.format)
+	return null
+}
+
+export async function extractAction(dir: string, node: INode) {
+	const target = await spawnDialog(ExtractArchiveModal, { node })
 	if (target === null) {
 		return null
 	}
 
-	await compressFiles(fileIds, dir + '/' + target)
-
-	// compressFiles will show a success or error message as needed, so null is
-	// returned to prevent the file list from showing its own with less context.
+	await extractArchive(node.fileid as number, dir + '/' + target)
 	return null
 }

--- a/tests/Unit/ArchiveFormatTest.php
+++ b/tests/Unit/ArchiveFormatTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Tests\Unit;
+
+use OCA\FilesZip\Exceptions\UnsupportedArchiveFormatException;
+use OCA\FilesZip\Model\ArchiveFormat;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ArchiveFormatTest extends TestCase {
+	public static function supportedFormats(): array {
+		return [
+			['archive.zip', ArchiveFormat::ZIP],
+			['archive.ZIP', ArchiveFormat::ZIP],
+			['archive.tar', ArchiveFormat::TAR],
+			['archive.tar.gz', ArchiveFormat::TAR_GZ],
+			['archive.tgz', ArchiveFormat::TAR_GZ],
+			['archive.7z', ArchiveFormat::SEVEN_ZIP],
+		];
+	}
+
+	#[DataProvider('supportedFormats')]
+	public function testSupportedFormat(string $filename, ArchiveFormat $expected): void {
+		self::assertSame($expected, ArchiveFormat::fromFilename($filename));
+	}
+
+	public function testUnsupportedFormat(): void {
+		$this->expectException(UnsupportedArchiveFormatException::class);
+		ArchiveFormat::fromFilename('archive.rar');
+	}
+}

--- a/tests/Unit/ArchivePathValidatorTest.php
+++ b/tests/Unit/ArchivePathValidatorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Tests\Unit;
+
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Service\ArchivePathValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ArchivePathValidatorTest extends TestCase {
+	private ArchivePathValidator $validator;
+
+	protected function setUp(): void {
+		$this->validator = new ArchivePathValidator();
+	}
+
+	public static function validPaths(): array {
+		return [
+			['file.txt', 'file.txt'],
+			['folder/file.txt', 'folder/file.txt'],
+			['folder\\file.txt', 'folder/file.txt'],
+			['./folder//file.txt', 'folder/file.txt'],
+			['Überblick/Foto 01.jpg', 'Überblick/Foto 01.jpg'],
+		];
+	}
+
+	#[DataProvider('validPaths')]
+	public function testValidPath(string $input, string $expected): void {
+		self::assertSame($expected, $this->validator->normalize($input));
+	}
+
+	public static function unsafePaths(): array {
+		$deepPath = implode('/', array_fill(0, 65, 'folder')) . '/file.txt';
+
+		return [
+			['../evil.txt'],
+			['folder/../../evil.txt'],
+			['/etc/passwd'],
+			['C:/Windows/win.ini'],
+			['C:\\Windows\\win.ini'],
+			['C:Windows/win.ini'],
+			["safe\0evil"],
+			["line\nbreak.txt"],
+			["tab\tname.txt"],
+			["delete\x7Fname.txt"],
+			["invalid\xFFutf8"],
+			['.'],
+			['./'],
+			[$deepPath],
+		];
+	}
+
+	#[DataProvider('unsafePaths')]
+	public function testUnsafePath(string $input): void {
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->validator->normalize($input);
+	}
+}

--- a/tests/Unit/SevenZipBinaryTest.php
+++ b/tests/Unit/SevenZipBinaryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Tests\Unit;
+
+use OCA\FilesZip\Service\SevenZipBinary;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SevenZipBinaryTest extends TestCase {
+	public static function versionOutputProvider(): array {
+		return [
+			['7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov', '25.01'],
+			['7-Zip 26.03 (x64) : Copyright (c) 1999-2026 Igor Pavlov', '26.03'],
+			['7z 25.01', '25.01'],
+			['unexpected output', null],
+		];
+	}
+
+	#[DataProvider('versionOutputProvider')]
+	public function testParseVersion(string $output, ?string $expected): void {
+		self::assertSame($expected, SevenZipBinary::parseVersion($output));
+	}
+
+	public function testMinimumVersionIsSecurityFloor(): void {
+		self::assertFalse(version_compare('24.09', SevenZipBinary::MINIMUM_VERSION, '>='));
+		self::assertTrue(version_compare('25.01', SevenZipBinary::MINIMUM_VERSION, '>='));
+		self::assertTrue(version_compare('26.03', SevenZipBinary::MINIMUM_VERSION, '>='));
+	}
+}

--- a/tests/Unit/SevenZipInspectorTest.php
+++ b/tests/Unit/SevenZipInspectorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Tests\Unit;
+
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Service\ArchivePathValidator;
+use OCA\FilesZip\Service\SevenZipInspector;
+use PHPUnit\Framework\TestCase;
+
+final class SevenZipInspectorTest extends TestCase {
+	private SevenZipInspector $inspector;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->inspector = new SevenZipInspector(new ArchivePathValidator());
+	}
+
+	public function testRegularFilesAndDirectoriesAreAccepted(): void {
+		$listing = $this->listing([
+			[
+				'Path' => 'folder',
+				'Size' => '0',
+				'Folder' => '+',
+				'Attributes' => 'D_ drwxr-xr-x',
+				'Encrypted' => '-',
+			],
+			[
+				'Path' => 'folder/hello.txt',
+				'Size' => '13',
+				'Folder' => '-',
+				'Attributes' => 'A_ -rw-r--r--',
+				'Encrypted' => '-',
+			],
+		]);
+
+		$entries = $this->inspector->inspect($listing, 128);
+
+		self::assertCount(2, $entries);
+		self::assertTrue($entries[0]->directory);
+		self::assertSame('folder/hello.txt', $entries[1]->path);
+		self::assertSame(13, $entries[1]->size);
+	}
+
+	public function testSymbolicLinkIsRejected(): void {
+		$listing = $this->listing([[
+			'Path' => 'link',
+			'Size' => '6',
+			'Folder' => '-',
+			'Attributes' => 'A_ lrwxrwxrwx',
+			'Symbolic Link' => '../etc',
+			'Encrypted' => '-',
+		]]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	public function testHardLinkIsRejected(): void {
+		$listing = $this->listing([[
+			'Path' => 'hardlink',
+			'Size' => '4',
+			'Folder' => '-',
+			'Attributes' => 'A_ -rw-r--r--',
+			'Hard Link' => 'target',
+			'Encrypted' => '-',
+		]]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	public function testTraversalIsRejected(): void {
+		$listing = $this->listing([[
+			'Path' => '../outside.txt',
+			'Size' => '1',
+			'Folder' => '-',
+			'Attributes' => 'A_ -rw-r--r--',
+			'Encrypted' => '-',
+		]]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	public function testDuplicateNormalizedPathIsRejected(): void {
+		$listing = $this->listing([
+			[
+				'Path' => 'folder//file.txt',
+				'Size' => '1',
+				'Folder' => '-',
+				'Attributes' => 'A_ -rw-r--r--',
+				'Encrypted' => '-',
+			],
+			[
+				'Path' => 'folder/file.txt',
+				'Size' => '1',
+				'Folder' => '-',
+				'Attributes' => 'A_ -rw-r--r--',
+				'Encrypted' => '-',
+			],
+		]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	public function testEncryptedEntryIsRejected(): void {
+		$listing = $this->listing([[
+			'Path' => 'secret.txt',
+			'Size' => '4',
+			'Folder' => '-',
+			'Attributes' => 'A_ -rw-------',
+			'Encrypted' => '+',
+		]]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	public function testSpecialUnixFileIsRejected(): void {
+		$listing = $this->listing([[
+			'Path' => 'pipe',
+			'Size' => '0',
+			'Folder' => '-',
+			'Attributes' => 'A_ prw-r--r--',
+			'Encrypted' => '-',
+		]]);
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($listing, 128);
+	}
+
+	/**
+	 * @param list<array<string, string>> $entries
+	 */
+	private function listing(array $entries): string {
+		$output = "Path = test.7z\nType = 7z\nPhysical Size = 128\n\n----------\n";
+		foreach ($entries as $entry) {
+			foreach ($entry as $key => $value) {
+				$output .= $key . ' = ' . $value . "\n";
+			}
+			$output .= "\n";
+		}
+		return $output;
+	}
+}

--- a/tests/Unit/TarInspectorTest.php
+++ b/tests/Unit/TarInspectorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Happyfeet01
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesZip\Tests\Unit;
+
+use OCA\FilesZip\Exceptions\UnsafeArchiveEntryException;
+use OCA\FilesZip\Service\ArchivePathValidator;
+use OCA\FilesZip\Service\TarInspector;
+use PHPUnit\Framework\TestCase;
+
+final class TarInspectorTest extends TestCase {
+	private TarInspector $inspector;
+	/** @var list<string> */
+	private array $temporaryFiles = [];
+
+	protected function setUp(): void {
+		$this->inspector = new TarInspector(new ArchivePathValidator());
+	}
+
+	protected function tearDown(): void {
+		foreach ($this->temporaryFiles as $path) {
+			@unlink($path);
+		}
+	}
+
+	public function testInspectsRegularFilesAndDirectories(): void {
+		$tar = $this->tar([
+			['folder/', '', '5', ''],
+			['folder/file.txt', 'hello', '0', ''],
+		]);
+		$path = $this->writeTemp($tar, '.tar');
+
+		$entries = $this->inspector->inspect($path, false);
+
+		self::assertCount(2, $entries);
+		self::assertSame('folder', $entries[0]->path);
+		self::assertTrue($entries[0]->directory);
+		self::assertSame('folder/file.txt', $entries[1]->path);
+		self::assertSame(5, $entries[1]->size);
+		self::assertFalse($entries[1]->directory);
+	}
+
+	public function testInspectsGzipCompressedTar(): void {
+		if (!function_exists('gzencode')) {
+			self::markTestSkipped('zlib is not available');
+		}
+
+		$tar = $this->tar([
+			['file.txt', 'hello', '0', ''],
+		]);
+		$compressed = gzencode($tar);
+		self::assertNotFalse($compressed);
+		$path = $this->writeTemp($compressed, '.tar.gz');
+
+		$entries = $this->inspector->inspect($path, true);
+		self::assertCount(1, $entries);
+		self::assertSame('file.txt', $entries[0]->path);
+	}
+
+	public function testRejectsParentTraversal(): void {
+		$path = $this->writeTemp($this->tar([
+			['../outside.txt', 'owned', '0', ''],
+		]), '.tar');
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($path, false);
+	}
+
+	public function testRejectsSymlink(): void {
+		$path = $this->writeTemp($this->tar([
+			['link', '', '2', '../../etc/passwd'],
+		]), '.tar');
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($path, false);
+	}
+
+	public function testRejectsHardlink(): void {
+		$path = $this->writeTemp($this->tar([
+			['hardlink', '', '1', 'file.txt'],
+		]), '.tar');
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($path, false);
+	}
+
+	public function testRejectsDuplicateDestinationPath(): void {
+		$path = $this->writeTemp($this->tar([
+			['same.txt', 'one', '0', ''],
+			['same.txt', 'two', '0', ''],
+		]), '.tar');
+
+		$this->expectException(UnsafeArchiveEntryException::class);
+		$this->inspector->inspect($path, false);
+	}
+
+	/**
+	 * @param list<array{0: string, 1: string, 2: string, 3: string}> $entries
+	 */
+	private function tar(array $entries): string {
+		$archive = '';
+		foreach ($entries as [$name, $data, $type, $linkName]) {
+			$archive .= $this->tarHeader($name, strlen($data), $type, $linkName);
+			$archive .= $data;
+			$padding = (512 - (strlen($data) % 512)) % 512;
+			$archive .= str_repeat("\0", $padding);
+		}
+
+		return $archive . str_repeat("\0", 1024);
+	}
+
+	private function tarHeader(string $name, int $size, string $type, string $linkName): string {
+		self::assertLessThanOrEqual(100, strlen($name), 'Test TAR name must fit the classic header');
+		self::assertLessThanOrEqual(100, strlen($linkName), 'Test TAR link name must fit the classic header');
+
+		$header = str_repeat("\0", 512);
+		$header = substr_replace($header, str_pad($name, 100, "\0"), 0, 100);
+		$header = substr_replace($header, "0000644\0", 100, 8);
+		$header = substr_replace($header, "0000000\0", 108, 8);
+		$header = substr_replace($header, "0000000\0", 116, 8);
+		$header = substr_replace($header, sprintf('%011o', $size) . "\0", 124, 12);
+		$header = substr_replace($header, sprintf('%011o', 0) . "\0", 136, 12);
+		$header = substr_replace($header, str_repeat(' ', 8), 148, 8);
+		$header = substr_replace($header, $type, 156, 1);
+		$header = substr_replace($header, str_pad($linkName, 100, "\0"), 157, 100);
+		$header = substr_replace($header, "ustar\0", 257, 6);
+		$header = substr_replace($header, '00', 263, 2);
+
+		$checksum = array_sum(unpack('C*', $header));
+		$header = substr_replace($header, sprintf('%06o', $checksum) . "\0 ", 148, 8);
+		return $header;
+	}
+
+	private function writeTemp(string $contents, string $suffix): string {
+		$base = tempnam(sys_get_temp_dir(), 'files_zip_test_');
+		self::assertNotFalse($base);
+		$path = $base . $suffix;
+		rename($base, $path);
+		file_put_contents($path, $contents);
+		$this->temporaryFiles[] = $path;
+		return $path;
+	}
+}


### PR DESCRIPTION
## Summary

This extends `files_zip` from ZIP-only compression into a more complete archive workflow while keeping the existing ZIP compression endpoint and implementation intact.

### Archive support

| Format | Compress | Extract |
| --- | --- | --- |
| ZIP | Yes | Yes |
| TAR | Yes with supported 7-Zip backend | Yes |
| TAR.GZ / TGZ | Yes with supported 7-Zip backend | Yes |
| 7z | Yes with supported 7-Zip backend | Yes with supported 7-Zip backend |

The file action uses one compression dialog with a format selector. Created archives are placed in the currently opened folder. Extraction creates a separate folder based on the archive name.

## Security design

Archive contents are treated as untrusted input. The implementation intentionally avoids direct archive extraction APIs and validates entries before writing them through the Nextcloud Files API.

Among other checks, it rejects or limits:

- `../` and absolute-path traversal
- Windows drive paths
- symlinks, hard links and special filesystem objects
- duplicate normalized destinations
- excessive nesting and entry counts
- excessive expanded sizes and suspicious compression ratios
- encrypted/password-protected 7z entries
- overwrite of existing extraction/compression targets
- incoming shares where downloading is disabled

For optional 7z support, the backend is deliberately restricted to `/usr/bin/7z` version 25.01 or newer. Commands use `proc_open()` with argument arrays rather than a shell. 7-Zip is never allowed to extract directly into the Nextcloud destination: approved files are streamed individually to controlled temporary files and then written through `OCP\Files`.

`SECURITY-DESIGN.md` documents the intended security invariants in more detail.

## Compatibility

- Existing `/api/v1/zip` behavior remains in place for ZIP creation.
- TAR/TAR.GZ/7z compression and 7z extraction are exposed only when the supported 7-Zip backend is available.
- ZIP/TAR/TAR.GZ extraction does not require the external 7-Zip backend.
- Compression and extraction run as background jobs and use Nextcloud notifications.

## Testing

Tested end-to-end on Nextcloud 34.0.3.2 on Debian Trixie:

- ZIP create + extract
- TAR.GZ create + extract
- 7z create + extract
- output is created in the currently opened folder
- extraction into a same-named subfolder

Unit tests cover archive format/path validation plus TAR and 7z inspection behavior.

This addresses the extraction request in #32.